### PR TITLE
XIVY-12288 only show class name of type in table

### DIFF
--- a/integrations/standalone/src/mock/dataclass-client-mock.ts
+++ b/integrations/standalone/src/mock/dataclass-client-mock.ts
@@ -37,7 +37,7 @@ export class DataClassClientMock implements Client {
         },
         {
           name: 'conversation',
-          type: 'String',
+          type: 'mock.Conversation',
           modifiers: [],
           comment: 'Transcript of the conversation.',
           annotations: []

--- a/integrations/standalone/tests/mock/dataclass-editor.spec.ts
+++ b/integrations/standalone/tests/mock/dataclass-editor.spec.ts
@@ -111,3 +111,10 @@ test.describe('delete field', async () => {
     await editor.detail.expectToBeDataClass();
   });
 });
+
+test('type', async () => {
+  const row = editor.table.row(3);
+  await expect(row.column(1).locator).toHaveText('Conversation');
+  await row.locator.click();
+  await expect(editor.detail.type.locator).toHaveValue('mock.Conversation');
+});

--- a/integrations/standalone/tests/pageobjects/Table.ts
+++ b/integrations/standalone/tests/pageobjects/Table.ts
@@ -22,7 +22,7 @@ export class Row {
     this.locator = rowsLocator.nth(index);
   }
 
-  private column(column: number) {
+  column(column: number) {
     return new Cell(this.locator, column);
   }
 

--- a/packages/dataclass-editor/src/components/dataclass/data/dataclass-utils.test.ts
+++ b/packages/dataclass-editor/src/components/dataclass/data/dataclass-utils.test.ts
@@ -1,5 +1,5 @@
 import type { DataClass } from './dataclass';
-import { isEntityClass } from './dataclass-utils';
+import { className, isEntityClass } from './dataclass-utils';
 
 describe('isEntityClass', () => {
   test('true', () => {
@@ -10,5 +10,15 @@ describe('isEntityClass', () => {
   test('false', () => {
     const dataClass = {} as DataClass;
     expect(isEntityClass(dataClass)).toBeFalsy();
+  });
+});
+
+describe('className', () => {
+  test('qualified', () => {
+    expect(className('ch.ivyteam.ivy.ClassName')).toEqual('ClassName');
+  });
+
+  test('notQualified', () => {
+    expect(className('ClassName')).toEqual('ClassName');
   });
 });

--- a/packages/dataclass-editor/src/components/dataclass/data/dataclass-utils.ts
+++ b/packages/dataclass-editor/src/components/dataclass/data/dataclass-utils.ts
@@ -3,3 +3,11 @@ import type { DataClass } from './dataclass';
 export const isEntityClass = (dataClass: DataClass) => {
   return !!dataClass.entity;
 };
+
+export const className = (qualifiedName: string) => {
+  const lastDotIndex = qualifiedName.lastIndexOf('.');
+  if (lastDotIndex === -1) {
+    return qualifiedName;
+  }
+  return qualifiedName.substring(lastDotIndex + 1);
+};

--- a/packages/dataclass-editor/src/components/dataclass/master/DataClassMasterContent.css
+++ b/packages/dataclass-editor/src/components/dataclass/master/DataClassMasterContent.css
@@ -2,11 +2,3 @@
   margin: var(--size-3);
   min-height: 0;
 }
-
-.cell-with-tooltip {
-  display: inline-block;
-}
-
-td .ui-tooltip-content {
-  color: var(--body);
-}

--- a/packages/dataclass-editor/src/components/dataclass/master/DataClassMasterContent.css
+++ b/packages/dataclass-editor/src/components/dataclass/master/DataClassMasterContent.css
@@ -2,3 +2,11 @@
   margin: var(--size-3);
   min-height: 0;
 }
+
+.cell-with-tooltip {
+  display: inline-block;
+}
+
+td .ui-tooltip-content {
+  color: var(--body);
+}

--- a/packages/dataclass-editor/src/components/dataclass/master/DataClassMasterContent.tsx
+++ b/packages/dataclass-editor/src/components/dataclass/master/DataClassMasterContent.tsx
@@ -43,7 +43,7 @@ export const DataClassMasterContent = () => {
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className='cell-with-tooltip'>{className(cell.getValue())}</div>
+              <span className='cell-with-tooltip'>{className(cell.getValue())}</span>
             </TooltipTrigger>
             <TooltipContent>
               <span>{cell.getValue()}</span>

--- a/packages/dataclass-editor/src/components/dataclass/master/DataClassMasterContent.tsx
+++ b/packages/dataclass-editor/src/components/dataclass/master/DataClassMasterContent.tsx
@@ -10,6 +10,10 @@ import {
   TableBody,
   TableCell,
   TableResizableHeader,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
   useReadonly,
   useTableSelect
 } from '@axonivy/ui-components';
@@ -17,6 +21,7 @@ import { IvyIcons } from '@axonivy/ui-icons';
 import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
 import { useAppContext } from '../../../context/AppContext';
 import { type DataClassField } from '../data/dataclass';
+import { className } from '../data/dataclass-utils';
 import { AddFieldDialog } from './AddFieldDialog';
 import './DataClassMasterContent.css';
 
@@ -34,7 +39,18 @@ export const DataClassMasterContent = () => {
     {
       accessorKey: 'type',
       header: 'Type',
-      cell: cell => <div>{cell.getValue()}</div>
+      cell: cell => (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className='cell-with-tooltip'>{className(cell.getValue())}</div>
+            </TooltipTrigger>
+            <TooltipContent>
+              <span>{cell.getValue()}</span>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )
     },
     {
       accessorKey: 'comment',


### PR DESCRIPTION
Fully qualified name can still be seen in the detail view and is provided as a tooltip in the table.

![image](https://github.com/user-attachments/assets/e7c89356-0b5b-4195-8ddc-61ca41d72492)
