### PR TITLE
XIVY-2942 improve switch to entity

### DIFF
--- a/integrations/standalone/tests/integration/entityclass.spec.ts
+++ b/integrations/standalone/tests/integration/entityclass.spec.ts
@@ -77,9 +77,9 @@ test('save data', async ({ page }) => {
 
   await editor.detail.dataClass.entity.expectToHaveValues('NewDatabaseTableName');
 
-  await expect(editor.table.rows).toHaveCount(2);
+  await expect(editor.table.rows).toHaveCount(3);
 
-  await editor.table.row(0).locator.click();
+  await editor.table.row(1).locator.click();
   await editor.detail.field.entity.accordion.open();
   await editor.detail.field.entity.databaseField.expectToHaveValues('NewDatabaseFieldName', 'NewDatabaseFieldLength', {
     id: true,
@@ -91,7 +91,7 @@ test('save data', async ({ page }) => {
     Version: false
   });
 
-  await editor.table.row(1).locator.click();
+  await editor.table.row(2).locator.click();
   await editor.detail.field.entity.accordion.open();
   await editor.detail.field.entity.association.expectToHaveValues(
     'One-to-One',

--- a/integrations/standalone/tests/mock/detail-dataclass-entity.spec.ts
+++ b/integrations/standalone/tests/mock/detail-dataclass-entity.spec.ts
@@ -46,7 +46,7 @@ describe('collapsible state', async () => {
         const entity = editor.detail.field.entity;
 
         await editor.detail.dataClass.general.classType.fillValues('Entity');
-        await editor.table.row(0).locator.click();
+        await editor.table.row(1).locator.click();
         await entity.accordion.open();
 
         await entity.databaseField.collapsible.expectToBeClosed();
@@ -69,7 +69,7 @@ describe('collapsible state', async () => {
         const entity = editor.detail.field.entity;
 
         await editor.detail.dataClass.general.classType.fillValues('Entity');
-        await editor.table.row(0).locator.click();
+        await editor.table.row(1).locator.click();
         await entity.accordion.open();
 
         await entity.databaseField.collapsible.expectToBeClosed();
@@ -91,7 +91,7 @@ describe('collapsible state', async () => {
         const entity = editor.detail.field.entity;
 
         await editor.detail.dataClass.general.classType.fillValues('Entity');
-        await editor.table.row(0).locator.click();
+        await editor.table.row(1).locator.click();
         await entity.accordion.open();
 
         await entity.databaseField.collapsible.expectToBeClosed();

--- a/integrations/standalone/tests/mock/detail-field-entity-database-field.spec.ts
+++ b/integrations/standalone/tests/mock/detail-field-entity-database-field.spec.ts
@@ -11,7 +11,7 @@ test('name', async () => {
   const databaseFieldName = editor.detail.field.entity.databaseField.name;
 
   await editor.detail.dataClass.general.classType.fillValues('Entity');
-  await editor.table.row(0).locator.click();
+  await editor.table.row(1).locator.click();
   await editor.detail.field.entity.accordion.open();
   await editor.detail.field.entity.databaseField.collapsible.open();
 
@@ -45,7 +45,7 @@ test('length', async () => {
   const databaseFieldLength = editor.detail.field.entity.databaseField.length;
 
   await editor.detail.dataClass.general.classType.fillValues('Entity');
-  await editor.table.row(0).locator.click();
+  await editor.table.row(1).locator.click();
   await editor.detail.field.entity.accordion.open();
   await editor.detail.field.entity.databaseField.collapsible.open();
 
@@ -69,7 +69,7 @@ test('properties', async () => {
   const databaseField = editor.detail.field.entity.databaseField;
 
   await editor.detail.dataClass.general.classType.fillValues('Entity');
-  await editor.table.row(2).locator.click();
+  await editor.table.row(3).locator.click();
   await editor.detail.field.entity.accordion.open();
   await databaseField.collapsible.open();
 

--- a/integrations/standalone/tests/mock/editor.spec.ts
+++ b/integrations/standalone/tests/mock/editor.spec.ts
@@ -23,7 +23,7 @@ test('headers', async () => {
   await expect(editor.title).toHaveText('Entity Class - Interview');
   await expect(editor.detail.title).toHaveText('Entity Class - Interview');
 
-  await editor.table.row(0).locator.click();
+  await editor.table.row(1).locator.click();
   await expect(editor.detail.title).toHaveText('Attribute - firstName');
 });
 

--- a/integrations/standalone/tests/mock/master.spec.ts
+++ b/integrations/standalone/tests/mock/master.spec.ts
@@ -8,11 +8,28 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('add field', async () => {
-  test('add', async () => {
-    await editor.addField('newAttribute', 'String');
-    await expect(editor.table.rows).toHaveCount(5);
-    await editor.table.row(4).expectToBeSelected();
-    await editor.table.row(4).expectToHaveValues('newAttribute', 'String', '');
+  test.describe('add', async () => {
+    test('data class', async () => {
+      await editor.addField('newAttribute', 'String');
+      await expect(editor.table.rows).toHaveCount(5);
+      await editor.table.row(4).expectToBeSelected();
+      await editor.table.row(4).expectToHaveValues('newAttribute', 'String', '');
+    });
+
+    test('entity class', async () => {
+      await editor.detail.dataClass.general.classType.fillValues('Entity');
+      await editor.addField('newAttribute', 'String');
+      await editor.detail.field.general.properties.fillValues(true);
+      await editor.detail.field.entity.accordion.open();
+      await editor.detail.field.entity.association.collapsible.open();
+      await editor.detail.field.entity.association.expectCascadeTypesToHaveCheckedState({
+        all: false,
+        persist: true,
+        merge: true,
+        remove: false,
+        refresh: false
+      });
+    });
   });
 
   test('default values', async () => {

--- a/packages/dataclass-editor/src/detail/dataclass/DataClassType.tsx
+++ b/packages/dataclass-editor/src/detail/dataclass/DataClassType.tsx
@@ -1,6 +1,6 @@
 import { BasicSelect, Collapsible, CollapsibleContent, CollapsibleTrigger } from '@axonivy/ui-components';
 import { useAppContext } from '../../context/AppContext';
-import type { DataClassType as ClassType } from '../../data/dataclass';
+import type { DataClassType as ClassType, DataClass } from '../../data/dataclass';
 import { classTypeOf } from '../../data/dataclass-utils';
 
 export const useClassType = () => {
@@ -18,22 +18,42 @@ export const useClassType = () => {
     if (classType === 'BUSINESS_DATA') {
       newDataClass.isBusinessCaseData = true;
     } else if (classType === 'ENTITY') {
-      newDataClass.entity = { tableName: '' };
-      newDataClass.fields.forEach(
-        field =>
-          (field.entity = {
-            databaseName: '',
-            databaseFieldLength: '',
-            cascadeTypes: [],
-            mappedByFieldName: '',
-            orphanRemoval: false
-          })
-      );
+      changeToEntityClass(newDataClass);
     }
 
     setDataClass(newDataClass);
   };
   return { classType: classTypeOf(dataClass), setClassType };
+};
+
+const changeToEntityClass = (newDataClass: DataClass) => {
+  newDataClass.entity = { tableName: '' };
+  newDataClass.fields.forEach(
+    field =>
+      (field.entity = {
+        databaseName: '',
+        databaseFieldLength: '',
+        cascadeTypes: ['PERSIST', 'MERGE'],
+        mappedByFieldName: '',
+        orphanRemoval: false
+      })
+  );
+  if (!newDataClass.fields.some(field => field.name === 'id')) {
+    newDataClass.fields.unshift({
+      name: 'id',
+      type: 'Integer',
+      comment: 'Identifier',
+      modifiers: ['PERSISTENT', 'ID', 'GENERATED'],
+      annotations: [],
+      entity: {
+        databaseName: '',
+        databaseFieldLength: '',
+        cascadeTypes: ['PERSIST', 'MERGE'],
+        mappedByFieldName: '',
+        orphanRemoval: false
+      }
+    });
+  }
 };
 
 const dataClassTypeItems: Array<{ value: ClassType; label: string }> = [

--- a/packages/dataclass-editor/src/master/AddFieldDialog.tsx
+++ b/packages/dataclass-editor/src/master/AddFieldDialog.tsx
@@ -24,7 +24,7 @@ export const validateFieldName = (name: string, dataClass: DataClass): MessageDa
   if (name.trim() === '') {
     return toErrorMessage('Name cannot be empty.');
   }
-  if (dataClass.fields.map(field => field.name).includes(name)) {
+  if (dataClass.fields.some(field => field.name === name)) {
     return toErrorMessage('Name is already taken.');
   }
 };
@@ -58,7 +58,7 @@ export const AddFieldDialog = ({ table }: AddFieldDialogProps) => {
   };
 
   const addField = () => {
-    const newField = {
+    const newField: DataClassField = {
       name: name,
       type: type,
       comment: '',
@@ -68,7 +68,7 @@ export const AddFieldDialog = ({ table }: AddFieldDialogProps) => {
         ? {
             databaseName: '',
             databaseFieldLength: '',
-            cascadeTypes: [],
+            cascadeTypes: ['PERSIST', 'MERGE'],
             mappedByFieldName: '',
             orphanRemoval: false
           }


### PR DESCRIPTION
automatically create an id field
initialize `cascadeTypes` of fields with `['PERSIST', 'MERGE']`
initialize `cascadeTypes` also when creating a new field