### PR TITLE
XIVY-15138 table fields sort and move

### DIFF
--- a/integrations/standalone/tests/mock/detail-dataclass-entity.spec.ts
+++ b/integrations/standalone/tests/mock/detail-dataclass-entity.spec.ts
@@ -14,7 +14,7 @@ test('accordion state', async () => {
   await editor.table.row(0).locator.click();
   await expect(editor.detail.field.entity.accordion.locator).toBeHidden();
 
-  await editor.table.header.click();
+  await editor.table.unselect();
   await editor.detail.dataClass.general.classType.fillValues('Entity');
   await editor.detail.dataClass.entity.accordion.expectToBeClosed();
 

--- a/integrations/standalone/tests/mock/editor.spec.ts
+++ b/integrations/standalone/tests/mock/editor.spec.ts
@@ -31,14 +31,14 @@ test('detail', async () => {
   await editor.detail.expectToBeDataClass();
   await editor.table.row(0).locator.click();
   await editor.detail.expectToBeField();
-  await editor.table.header.click();
+  await editor.table.unselect();
   await editor.detail.expectToBeDataClass();
 
   await editor.detail.dataClass.general.classType.fillValues('Entity');
   await editor.detail.expectToBeDataClass(true);
   await editor.table.row(0).locator.click();
   await editor.detail.expectToBeField(true);
-  await editor.table.header.click();
+  await editor.table.unselect();
   await editor.detail.expectToBeDataClass(true);
 });
 

--- a/integrations/standalone/tests/mock/master.spec.ts
+++ b/integrations/standalone/tests/mock/master.spec.ts
@@ -105,3 +105,13 @@ test.describe('delete field', async () => {
     await editor.detail.expectToBeDataClass();
   });
 });
+
+test('disable reorder', async () => {
+  await editor.table.expectToBeReorderable();
+  await editor.table.header(0).sort.locator.click();
+  await editor.table.expectToNotBeReorderable();
+  await editor.table.header(0).sort.locator.click();
+  await editor.table.expectToNotBeReorderable();
+  await editor.table.header(0).sort.locator.click();
+  await editor.table.expectToBeReorderable();
+});

--- a/integrations/standalone/tests/pageobjects/abstract/Table.ts
+++ b/integrations/standalone/tests/pageobjects/abstract/Table.ts
@@ -1,13 +1,14 @@
 import type { Locator } from '@playwright/test';
 import { expect } from '@playwright/test';
+import { Button } from './Button';
 
 export class Table {
   readonly rows: Locator;
-  readonly header: Locator;
+  readonly headers: Locator;
 
   constructor(parentLocator: Locator) {
     this.rows = parentLocator.locator('tbody tr');
-    this.header = parentLocator.locator('.ui-table-header');
+    this.headers = parentLocator.locator('.ui-table-head');
   }
 
   row(index: number) {
@@ -19,6 +20,36 @@ export class Table {
     for (let i = 0; i < values.length; i++) {
       await this.row(i).expectToHaveValues(...values[i]);
     }
+  }
+
+  header(index: number) {
+    return new TableHeader(this.headers, index);
+  }
+
+  async unselect() {
+    await this.header(0).locator.click();
+  }
+
+  async expectToBeReorderable() {
+    for (let i = 0; i < (await this.rows.count()); i++) {
+      await expect(this.row(i).locator).toHaveClass(/ui-dnd-row/);
+    }
+  }
+
+  async expectToNotBeReorderable() {
+    for (let i = 0; i < (await this.rows.count()); i++) {
+      await expect(this.row(i).locator).not.toHaveClass(/ui-dnd-row/);
+    }
+  }
+}
+
+export class TableHeader {
+  readonly locator: Locator;
+  readonly sort: Button;
+
+  constructor(headersLocator: Locator, index: number) {
+    this.locator = headersLocator.nth(index);
+    this.sort = new Button(this.locator);
   }
 }
 

--- a/packages/dataclass-editor/src/master/AddFieldDialog.tsx
+++ b/packages/dataclass-editor/src/master/AddFieldDialog.tsx
@@ -51,7 +51,7 @@ type AddFieldDialogProps = {
 };
 
 export const AddFieldDialog = ({ table }: AddFieldDialogProps) => {
-  const { dataClass, setDataClass, setSelectedField } = useAppContext();
+  const { dataClass, setDataClass } = useAppContext();
 
   const [name, setName] = useState('');
   const [type, setType] = useState('');
@@ -86,7 +86,6 @@ export const AddFieldDialog = ({ table }: AddFieldDialogProps) => {
     const newDataClass = structuredClone(dataClass);
     newDataClass.fields = newFields;
     setDataClass(newDataClass);
-    setSelectedField(newDataClass.fields.length - 1);
   };
 
   const allInputsValid = () => !nameValidationMessage && !typeValidationMessage;

--- a/packages/dataclass-editor/src/master/ValidationRow.css
+++ b/packages/dataclass-editor/src/master/ValidationRow.css
@@ -10,3 +10,8 @@
 .ui-table-row:has(+ .ui-table-row.row-warning) {
   border-bottom: 1px solid var(--warning-color);
 }
+
+tr:not(.ui-dnd-row) .ivy-edit-dots {
+  color: var(--N300);
+  cursor: not-allowed;
+}

--- a/packages/dataclass-editor/src/master/ValidationRow.test.ts
+++ b/packages/dataclass-editor/src/master/ValidationRow.test.ts
@@ -1,4 +1,28 @@
-import { rowClassName } from './ValidationRow';
+import { customRenderHook } from '../context/test-utils/test-utils';
+import type { DataClass } from '../data/dataclass';
+import { rowClassName, useUpdateOrder } from './ValidationRow';
+
+test('useUpdateOrder', () => {
+  const dataClass = {
+    fields: [{ name: 'field0' }, { name: 'field1' }, { name: 'field2' }, { name: 'field3' }, { name: 'field4' }]
+  } as DataClass;
+  let newDataClass = {} as DataClass;
+  const view = customRenderHook(() => useUpdateOrder(), {
+    wrapperProps: { appContext: { dataClass, setDataClass: dataClass => (newDataClass = dataClass) } }
+  });
+
+  const originalDataClass = structuredClone(dataClass);
+  view.result.current('0', '2');
+  expect(dataClass).toEqual(originalDataClass);
+
+  expect(newDataClass.fields).toEqual([{ name: 'field1' }, { name: 'field2' }, { name: 'field0' }, { name: 'field3' }, { name: 'field4' }]);
+
+  view.result.current('2', '4');
+  expect(newDataClass.fields).toEqual([{ name: 'field0' }, { name: 'field1' }, { name: 'field3' }, { name: 'field4' }, { name: 'field2' }]);
+
+  view.result.current('4', '0');
+  expect(newDataClass.fields).toEqual([{ name: 'field4' }, { name: 'field0' }, { name: 'field1' }, { name: 'field2' }, { name: 'field3' }]);
+});
 
 test('rowClassName', () => {
   expect(rowClassName([{ variant: 'info' }, { variant: 'info' }, { variant: 'info' }])).toBeUndefined();

--- a/packages/dataclass-editor/src/master/ValidationRow.tsx
+++ b/packages/dataclass-editor/src/master/ValidationRow.tsx
@@ -1,9 +1,18 @@
-import { MessageRow, SelectRow, TableCell, type MessageData } from '@axonivy/ui-components';
+import { arraymove, MessageRow, ReorderRow, SelectRow, TableCell, type MessageData } from '@axonivy/ui-components';
 import { flexRender, type Row } from '@tanstack/react-table';
 import { useAppContext } from '../context/AppContext';
 import type { DataClassField } from '../data/dataclass';
 import './ValidationRow.css';
 import { useValidation } from './useValidation';
+
+export const useUpdateOrder = () => {
+  const { dataClass, setDataClass } = useAppContext();
+  return (moveId: string, targetId: string) => {
+    const newDataClass = structuredClone(dataClass);
+    arraymove(newDataClass.fields, parseInt(moveId), parseInt(targetId));
+    setDataClass(newDataClass);
+  };
+};
 
 export const rowClassName = (messages: Array<MessageData>) => {
   if (messages.some(message => message.variant === 'error')) {
@@ -16,19 +25,22 @@ export const rowClassName = (messages: Array<MessageData>) => {
 
 type ValidationRowProps = {
   row: Row<DataClassField>;
+  isReorderable: boolean;
 };
 
-export const ValidationRow = ({ row }: ValidationRowProps) => {
-  const { setSelectedField } = useAppContext();
+export const ValidationRow = ({ row, isReorderable }: ValidationRowProps) => {
+  const updateOrder = useUpdateOrder();
   const messages = useValidation(row.original);
+
+  const RowComponent = isReorderable ? ReorderRow : SelectRow;
 
   return (
     <>
-      <SelectRow row={row} onClick={() => setSelectedField(row.index)} className={rowClassName(messages)}>
+      <RowComponent id={row.index.toString()} row={row} className={rowClassName(messages)} updateOrder={updateOrder}>
         {row.getVisibleCells().map(cell => (
           <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
         ))}
-      </SelectRow>
+      </RowComponent>
       {messages.map((message, index) => (
         <MessageRow key={index} columnCount={3} message={message} />
       ))}


### PR DESCRIPTION
- Make rows sortable.
- Make rows reorderable.
  - Rows can only be reordered if they are not sorted.
- Listen for table selection changes to update the selected field instead of having to call it individually.

![sort-and-reorder](https://github.com/user-attachments/assets/a663a00e-1105-40ce-9a79-03daa3473979)
