### PR TITLE
XIVY-15045 Add allTypes-search to TypeBrowser

### DIFF
--- a/packages/dataclass-editor/src/context/useMeta.ts
+++ b/packages/dataclass-editor/src/context/useMeta.ts
@@ -8,10 +8,12 @@ type NonUndefinedGuard<T> = T extends undefined ? never : T;
 export function useMeta<TMeta extends keyof MetaRequestTypes>(
   path: TMeta,
   args: MetaRequestTypes[TMeta][0],
-  initialData: NonUndefinedGuard<MetaRequestTypes[TMeta][1]>
+  initialData: NonUndefinedGuard<MetaRequestTypes[TMeta][1]>,
+  options?: { disable?: boolean }
 ): { data: MetaRequestTypes[TMeta][1] } {
   const client = useClient();
   return useQuery({
+    enabled: !options?.disable,
     queryKey: genQueryKey(path, args),
     queryFn: () => client.meta(path, args),
     initialData: initialData

--- a/packages/dataclass-editor/src/data/type-data.test.ts
+++ b/packages/dataclass-editor/src/data/type-data.test.ts
@@ -18,28 +18,36 @@ const nonIvyTypes: JavaType[] = [
   { fullQualifiedName: 'com.other.TypeD', packageName: 'com.other', simpleName: 'TypeD' }
 ];
 
+const ownTypes: JavaType[] = [{ fullQualifiedName: 'com.own.TypeE', packageName: 'com.own', simpleName: 'TypeE' }];
+
+const allTypes: JavaType[] = [
+  { fullQualifiedName: 'com.example.TypeB', packageName: 'com.example', simpleName: 'TypeB' },
+  { fullQualifiedName: 'ivy.IvyTypeF', packageName: 'ivy', simpleName: 'IvyTypeF' },
+  { fullQualifiedName: 'com.own.TypeE', packageName: 'com.own', simpleName: 'TypeE' }
+];
+
 describe('typeData', () => {
   test('returns empty array if both input arrays are empty', () => {
-    const result = typeData([], []);
+    const result = typeData([], [], [], [], false);
     expect(result).toEqual([]);
   });
 
   test('returns sorted data class nodes when dataClasses are provided', () => {
-    const result = typeData(dataClasses, []);
+    const result = typeData(dataClasses, [], [], [], false);
     expect(result).toHaveLength(2);
     expect(result[0].value).toBe('ClassA');
     expect(result[1].value).toBe('ClassB');
   });
 
   test('returns sorted non-Ivy type nodes when ivyTypes are provided', () => {
-    const result = typeData([], nonIvyTypes);
+    const result = typeData([], nonIvyTypes, [], [], false);
     expect(result).toHaveLength(2);
     expect(result[0].value).toBe('TypeC');
     expect(result[1].value).toBe('TypeD');
   });
 
   test('returns combined sorted nodes from dataClasses and non-Ivy and Ivy types', () => {
-    const result = typeData(dataClasses, [...nonIvyTypes, ...ivyTypes]);
+    const result = typeData(dataClasses, [...nonIvyTypes, ...ivyTypes], [], [], false);
     expect(result).toHaveLength(6);
     expect(result[0].value).toBe('ClassA');
     expect(result[1].value).toBe('ClassB');
@@ -50,7 +58,7 @@ describe('typeData', () => {
   });
 
   test('correctly classifies and sorts Ivy and non-Ivy types', () => {
-    const result = typeData(dataClasses, ivyTypes);
+    const result = typeData(dataClasses, ivyTypes, [], [], false);
     expect(result).toHaveLength(4);
     expect(result[0].value).toBe('ClassA');
     expect(result[1].value).toBe('ClassB');
@@ -59,9 +67,50 @@ describe('typeData', () => {
   });
 
   test('returns nodes with correct icons', () => {
-    const result = typeData(dataClasses, ivyTypes);
+    const result = typeData(dataClasses, ivyTypes, [], [], false);
     expect(result[0].icon).toBe(IvyIcons.LetterD);
     expect(result[2].icon).toBe(IvyIcons.DataClass);
     expect(result[3].icon).toBe(IvyIcons.Ivy);
+  });
+
+  test('includes ownTypes if allTypesSearchActive is false', () => {
+    const result = typeData([], [], ownTypes, [], false);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe('TypeE');
+    expect(result[0].icon).toBe(IvyIcons.DataClass);
+  });
+
+  test('does not include ownTypes if allTypesSearchActive is true', () => {
+    const result = typeData([], [], ownTypes, [], true);
+    expect(result).toHaveLength(0);
+  });
+
+  test('returns sorted allTypes when allTypesSearchActive is true', () => {
+    const result = typeData([], [], [], allTypes, true);
+    expect(result).toHaveLength(3);
+    expect(result[0].value).toBe('IvyTypeF');
+    expect(result[1].value).toBe('TypeB');
+    expect(result[2].value).toBe('TypeE');
+  });
+
+  test('returns sorted combined types when allTypesSearchActive is true and filtered types are present', () => {
+    const result = typeData(dataClasses, ivyTypes, ownTypes, allTypes, true);
+    expect(result).toHaveLength(6);
+    expect(result[0].value).toBe('ClassA');
+    expect(result[1].value).toBe('ClassB');
+    expect(result[2].value).toBe('IvyTypeA');
+    expect(result[3].value).toBe('IvyTypeF');
+    expect(result[4].value).toBe('TypeB');
+    expect(result[5].value).toBe('TypeE');
+  });
+
+  test('sorts combined types correctly when allTypesSearchActive is false', () => {
+    const result = typeData(dataClasses, ivyTypes, ownTypes, allTypes, false);
+    expect(result).toHaveLength(5);
+    expect(result[0].value).toBe('TypeE');
+    expect(result[1].value).toBe('ClassA');
+    expect(result[2].value).toBe('ClassB');
+    expect(result[3].value).toBe('TypeB');
+    expect(result[4].value).toBe('IvyTypeA');
   });
 });

--- a/packages/dataclass-editor/src/data/type-data.ts
+++ b/packages/dataclass-editor/src/data/type-data.ts
@@ -2,44 +2,69 @@ import type { BrowserNode } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { DataclassType, JavaType } from '../protocol/types';
 
-export const typeData = (dataClasses: DataclassType[], ivyTypes: JavaType[]): Array<BrowserNode<DataclassType>> => {
-  const sortedDataClasses = dataClasses.sort((a, b) => a.name.localeCompare(b.name));
-
+export const typeData = (
+  dataClasses: DataclassType[],
+  ivyTypes: JavaType[],
+  ownTypes: JavaType[],
+  allTypes: JavaType[],
+  allTypesSearchActive: boolean
+): Array<BrowserNode<DataclassType>> => {
   const nonIvyTypes = ivyTypes.filter(type => !isIvyType(type.fullQualifiedName));
   const ivyOnlyTypes = ivyTypes.filter(type => isIvyType(type.fullQualifiedName));
+  const excludedFullQualifiedNames = new Set([
+    ...dataClasses.map(dc => dc.fullQualifiedName),
+    ...ivyTypes.map(type => type.fullQualifiedName)
+  ]);
 
+  const filteredAllTypes = allTypes.filter(type => !excludedFullQualifiedNames.has(type.fullQualifiedName));
+  const filteredOwnTypes = ownTypes.filter(type => !excludedFullQualifiedNames.has(type.fullQualifiedName));
+
+  const sortedDataClasses = dataClasses.sort((a, b) => a.name.localeCompare(b.name));
   const sortedNonIvyTypes = nonIvyTypes.sort((a, b) => a.simpleName.localeCompare(b.simpleName));
   const sortedIvyOnlyTypes = ivyOnlyTypes.sort((a, b) => a.simpleName.localeCompare(b.simpleName));
 
-  const dataClassNodes = sortedDataClasses.map<BrowserNode<DataclassType>>(dataClass => ({
-    value: dataClass.name,
-    info: dataClass.packageName,
-    icon: IvyIcons.LetterD,
-    data: dataClass,
-    children: [],
-    isLoaded: true
-  }));
+  const dataClassNodes = sortedDataClasses.map(dataClass =>
+    createNode({ ...dataClass, simpleName: dataClass.name }, IvyIcons.LetterD, dataClass)
+  );
+  const nonIvyTypeNodes = sortedNonIvyTypes.map(javaType => createNode(javaType, IvyIcons.DataClass));
+  const ivyTypeNodes = sortedIvyOnlyTypes.map(javaType => createNode(javaType, IvyIcons.Ivy));
+  const ownTypeNodes = filteredOwnTypes.map(javaType => createNode(javaType, IvyIcons.DataClass));
+  const allTypeNodes = filteredAllTypes.map(type => {
+    const icon = dataClasses.find(dc => dc.fullQualifiedName === type.fullQualifiedName)
+      ? IvyIcons.LetterD
+      : type.fullQualifiedName.includes('ivy')
+      ? IvyIcons.Ivy
+      : IvyIcons.DataClass;
+    return createNode(type, icon);
+  });
 
-  const nonIvyTypeNodes = sortedNonIvyTypes.map<BrowserNode<DataclassType>>(javaType => ({
-    value: javaType.simpleName,
-    info: javaType.packageName,
-    icon: IvyIcons.DataClass,
-    data: { ...javaType, name: javaType.simpleName, path: '' },
-    children: [],
-    isLoaded: true
-  }));
+  const combinedTypes = [
+    ...(allTypesSearchActive ? [] : ownTypeNodes),
+    ...dataClassNodes,
+    ...nonIvyTypeNodes,
+    ...ivyTypeNodes,
+    ...(allTypesSearchActive ? allTypeNodes : [])
+  ];
 
-  const ivyTypeNodes = sortedIvyOnlyTypes.map<BrowserNode<DataclassType>>(javaType => ({
-    value: javaType.simpleName,
-    info: javaType.packageName,
-    icon: IvyIcons.Ivy,
-    data: { ...javaType, name: javaType.simpleName, path: '' },
-    children: [],
-    isLoaded: true
-  }));
+  const sortedCombinedTypes =
+    allTypesSearchActive && (filteredAllTypes.length > 0 || filteredOwnTypes.length > 0)
+      ? combinedTypes.sort((a, b) => {
+          const infoComparison = a.value.localeCompare(b.value);
+          return infoComparison !== 0 ? infoComparison : a.info.localeCompare(b.info);
+        })
+      : combinedTypes;
 
-  return [...dataClassNodes, ...nonIvyTypeNodes, ...ivyTypeNodes];
+  return sortedCombinedTypes;
 };
+
+const createNode = (javaType: JavaType, icon: IvyIcons, data?: DataclassType): BrowserNode<DataclassType> => ({
+  value: javaType.simpleName,
+  info: javaType.packageName,
+  icon,
+  data: data ? data : { ...javaType, name: javaType.simpleName, path: '' },
+  children: [],
+  isLoaded: true
+});
 
 const isIvyType = (fullQualifiedName: string) => {
   return fullQualifiedName.includes('ivy');

--- a/packages/dataclass-editor/src/detail/field/browser/useTypeBrowser.tsx
+++ b/packages/dataclass-editor/src/detail/field/browser/useTypeBrowser.tsx
@@ -2,22 +2,47 @@ import { BasicCheckbox, useBrowser, type Browser, type BrowserNode } from '@axon
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { DataclassType } from '../../../protocol/types';
 import { typeBrowserApply } from './typeBrowserApply';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useMeta } from '../../../context/useMeta';
 import { typeData } from '../../../data/type-data';
 import { useAppContext } from '../../../context/AppContext';
 
 export const useTypeBrowser = (): Browser => {
   const { context } = useAppContext();
+  const [allTypesSearchActive, setAllTypesSearchActive] = useState<boolean>(false);
   const [typeAsList, setTypeAsList] = useState<boolean>(false);
+
   const dataClasses = useMeta('meta/scripting/dataClasses', context, []).data;
   const ivyTypes = useMeta('meta/scripting/ivyTypes', undefined, []).data;
-  const types = useMemo(() => typeData(dataClasses, ivyTypes), [dataClasses, ivyTypes]);
+
+  const [metaFilter, setMetaFilter] = useState('');
+  const ownTypes = useMeta('meta/scripting/ownTypes', { context, limit: 50, type: metaFilter }, [], { disable: allTypesSearchActive }).data;
+  const allDatatypes = useMeta('meta/scripting/allTypes', { context, limit: 150, type: metaFilter }, [], {
+    disable: !allTypesSearchActive
+  }).data;
+
+  const types = useMemo(
+    () => typeData(dataClasses, ivyTypes, ownTypes, allDatatypes, allTypesSearchActive),
+    [allDatatypes, allTypesSearchActive, dataClasses, ivyTypes, ownTypes]
+  );
   const typesList = useBrowser(types);
+  console.log(context);
+
+  useEffect(() => {
+    setMetaFilter(typesList.globalFilter.filter);
+  }, [allTypesSearchActive, typesList.globalFilter.filter]);
+
   return {
     name: 'Type',
     icon: IvyIcons.DataClass,
     browser: typesList,
+    header: !context.file.includes('/neo') ? (
+      <BasicCheckbox
+        label='Search over all Types'
+        checked={allTypesSearchActive}
+        onCheckedChange={() => setAllTypesSearchActive(!allTypesSearchActive)}
+      />
+    ) : undefined,
     footer: <BasicCheckbox label='Type as List' checked={typeAsList} onCheckedChange={() => setTypeAsList(!typeAsList)} />,
     infoProvider: row => typeBrowserApply(row?.original as BrowserNode<DataclassType>, ivyTypes, typeAsList),
     applyModifier: row => ({ value: typeBrowserApply(row.original as BrowserNode<DataclassType>, ivyTypes, typeAsList) })

--- a/packages/dataclass-editor/src/master/AddFieldDialog.tsx
+++ b/packages/dataclass-editor/src/master/AddFieldDialog.tsx
@@ -120,25 +120,27 @@ export const AddFieldDialog = ({ table }: AddFieldDialogProps) => {
         <DialogDescription>Choose the name and type of the attribute you want to add.</DialogDescription>
         <form onSubmit={event => event.preventDefault()}>
           <Flex direction='column' gap={2}>
-            <BasicField label='Name' message={nameValidationMessage} aria-label='Name'>
-              <Input value={name} onChange={event => setName(event.target.value)} />
-            </BasicField>
-            <InputFieldWithTypeBrowser value={type} message={typeValidationMessage} onChange={setType} />
+            <Flex direction='column' gap={2}>
+              <BasicField label='Name' message={nameValidationMessage} aria-label='Name'>
+                <Input value={name} onChange={event => setName(event.target.value)} />
+              </BasicField>
+              <InputFieldWithTypeBrowser value={type} message={typeValidationMessage} onChange={setType} />
+            </Flex>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button
+                  variant='primary'
+                  size='large'
+                  type='submit'
+                  aria-label='Create field'
+                  disabled={!allInputsValid()}
+                  onClick={addField}
+                >
+                  Create Attribute
+                </Button>
+              </DialogClose>
+            </DialogFooter>
           </Flex>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button
-                variant='primary'
-                size='large'
-                type='submit'
-                aria-label='Create field'
-                disabled={!allInputsValid()}
-                onClick={addField}
-              >
-                Create Attribute
-              </Button>
-            </DialogClose>
-          </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>

--- a/packages/dataclass-editor/src/protocol/types.ts
+++ b/packages/dataclass-editor/src/protocol/types.ts
@@ -54,6 +54,14 @@ export interface ClientContext {
 export interface MetaRequestTypes {
   'meta/scripting/dataClasses': [DataContext, DataclassType[]];
   'meta/scripting/ivyTypes': [void, JavaType[]];
+  'meta/scripting/allTypes': [TypeSearchRequest, JavaType[]];
+  'meta/scripting/ownTypes': [TypeSearchRequest, JavaType[]];
+}
+
+export interface TypeSearchRequest {
+  context: DataContext;
+  limit: number;
+  type: string;
 }
 
 export interface JavaType {


### PR DESCRIPTION
Frontent for PR: https://github.com/axonivy/core/pull/6984

I've added `allTypes` and `ownTypes` to the browser. If JDT is missing (as in Neo), the browser still works, returning only static dataclasses and ivytypes. With JDT, `ownTypes` appear first by default, followed by `dataClasses`, `primitiveTypes`, and `ivyTypes`. When 'Search for all Types' is checked, you can search `allTypes` meta, and filtering ensures no duplicates between `ownTypes`, `allTypes`, `ivyTypes`, and `dataClasses`.

![allTypes](https://github.com/user-attachments/assets/a99490e5-5ebf-4e1a-840f-269861e75667)

