### PR TITLE
improve jenkins artifacts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Launch Standalone (Chrome)",
       "type": "chrome",
       "request": "launch",
-      "url": "http://localhost:3002/?server=localhost:8081&app=designer&pmv=dataclass-test-project&file=dataclasses/dataclass/Data.d.json",
+      "url": "http://localhost:3002/?server=localhost:8081&app=designer&pmv=dataclass-test-project&file=dataclasses/dataclass/DataClass.d.json",
       "preLaunchTask": "Start Standalone",
       "postDebugTask": "Terminate All Tasks"
     },

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -20,7 +20,8 @@ pipeline {
             }
           }
           archiveArtifacts artifacts: '**/integrations/standalone/build/**', allowEmptyArchive: true
-          currentBuild.description = "<a href=${BUILD_URL}artifact/integrations/standalone/build/index.html>&raquo; Data Class Editor</a>" 
+          currentBuild.description = "<a href=${BUILD_URL}artifact/integrations/standalone/build/index.html?server=localhost:8081&secure=false&app=designer&pmv=dataclass-test-project&file=dataclasses/dataclass/DataClass.d.json>&raquo; Data Class Editor</a><br>" +
+            "<a href=${BUILD_URL}artifact/integrations/standalone/build/mock.html>&raquo; Data Class Editor Mock</a>"
 
           withChecks('ESLint') {
             recordIssues enabledForFailure: true, publishAllIssues: true, aggregatingResults: true, tools: [esLint(pattern: 'packages/**/eslint.xml,integrations/**/eslint.xml')], qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]

--- a/integrations/standalone/assembly.xml
+++ b/integrations/standalone/assembly.xml
@@ -15,6 +15,8 @@
       <directory>build</directory>
       <excludes>
         <exclude>favicon.ico</exclude>
+        <exclude>mock.html</exclude>
+        <exclude>*/mock*</exclude>
       </excludes>
       <outputDirectory>./META-INF/resources/dataclass-editor</outputDirectory>
     </fileSet>

--- a/integrations/standalone/vite.config.ts
+++ b/integrations/standalone/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   build: {
     outDir: 'build',
     chunkSizeWarningLimit: 5000,
-    rollupOptions: { input: { index: './index.html' } }
+    rollupOptions: { input: { index: './index.html', mock: './mock.html'  } }
   },
   server: { port: 3002 },
   resolve: {


### PR DESCRIPTION
add mock.html
make index.html work with local engine
change default data class to open to `DataClass`

[try it yourself](https://jenkins.ivyteam.io/job/dataclass-editor-client/job/mock-on-jenkins/5/)
![dataclass](https://github.com/user-attachments/assets/20c6424b-a2ff-45ac-8f22-318a311dcc4a)
