### PR TITLE
XIVY-15138 Add Multiselect on ctrl and remove/reorder multiselect

### DIFF
--- a/integrations/standalone/src/mock/dataclass-client-mock.ts
+++ b/integrations/standalone/src/mock/dataclass-client-mock.ts
@@ -7,6 +7,7 @@ import type {
   ValidationMessage
 } from '@axonivy/dataclass-editor/src/protocol/types';
 import { MetaMock } from './meta-mock';
+import type { DataClassField } from '@axonivy/dataclass-editor';
 
 export class DataClassClientMock implements Client {
   private dataClassData: Data = {
@@ -64,6 +65,10 @@ export class DataClassClientMock implements Client {
   }
 
   validate(): Promise<Array<ValidationMessage>> {
+    return Promise.resolve([]);
+  }
+
+  function(): Promise<Array<DataClassField>> {
     return Promise.resolve([]);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,17 +66,17 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "12.0.0-next.342",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.0-next.342.tgz",
-      "integrity": "sha512-hBwaxYEOQM9EuWtUey/9euK8shTmbVdK4TqGK5Y53JeYwHAZpiCdgvJq7hcLN8s1kC0nOmfgrcMn9iW79SMgaw==",
+      "version": "12.0.0-next.344",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.0-next.344.tgz",
+      "integrity": "sha512-Cm6LiJYkRZDMBTlzVfocVB0fO3J+qmn+NbP3/ASSIRBsLVDJdxR9HEkDzgjElAbZO++hBg/RHRheQM5kbeShKA==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0"
       }
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "12.0.0-next.342",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.0-next.342.tgz",
-      "integrity": "sha512-qTnzT7Jna4Ql5R7+mH0w/GVrD6UxFGT4iXcfjmmpYtm40CmcMk4hFFt2BIUZPOtCaw1zU6HY1Wjeok8Gx83bzw==",
+      "version": "12.0.0-next.344",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.0-next.344.tgz",
+      "integrity": "sha512-vEV9o61vaHdhCYsPRNbvjYDm5voWPYNkICP+W0ajuC0fRHYWlgZoynDyzNSijPJ9q/xZ0YQGp7Pb7223LFHjAA==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.1",
         "@radix-ui/react-checkbox": "1.1.2",
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@axonivy/ui-icons": {
-      "version": "12.0.0-next.342",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.0-next.342.tgz",
-      "integrity": "sha512-FicD20p+T+RUvpCdTHqYAcqjJFSmty2pmoFZMoJMeDZQTpYKlwL7DoSIroV4JtMiC8jfaaq4kdXgJ33XLBE74Q=="
+      "version": "12.0.0-next.344",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.0-next.344.tgz",
+      "integrity": "sha512-fo15PPFenwF9WRuQvZW1K/e5uKfUejQ5Y+WRsFvIGrWf8dAVqesj8dhBVkHOaWgoSMDQkR/rml5yfURC/YFcdg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
@@ -15282,9 +15282,9 @@
       "version": "12.0.0-next",
       "license": "Apache-2.0",
       "dependencies": {
-        "@axonivy/jsonrpc": "~12.0.0-next.342",
-        "@axonivy/ui-components": "~12.0.0-next.342",
-        "@axonivy/ui-icons": "~12.0.0-next.342",
+        "@axonivy/jsonrpc": "~12.0.0-next.344",
+        "@axonivy/ui-components": "~12.0.0-next.344",
+        "@axonivy/ui-icons": "~12.0.0-next.344",
         "@tanstack/react-query": "5.32.1",
         "@tanstack/react-query-devtools": "5.32.1",
         "react": "^18.2.0"

--- a/packages/dataclass-editor/package.json
+++ b/packages/dataclass-editor/package.json
@@ -17,9 +17,9 @@
   "types": "lib/index.d.ts",
   "main": "lib/editor.js",
   "dependencies": {
-    "@axonivy/jsonrpc": "~12.0.0-next.342",
-    "@axonivy/ui-components": "~12.0.0-next.342",
-    "@axonivy/ui-icons": "~12.0.0-next.342",
+    "@axonivy/jsonrpc": "~12.0.0-next.344",
+    "@axonivy/ui-components": "~12.0.0-next.344",
+    "@axonivy/ui-icons": "~12.0.0-next.344",
     "@tanstack/react-query": "5.32.1",
     "@tanstack/react-query-devtools": "5.32.1",
     "react": "^18.2.0"

--- a/packages/dataclass-editor/src/master/ValidationRow.test.ts
+++ b/packages/dataclass-editor/src/master/ValidationRow.test.ts
@@ -1,28 +1,4 @@
-import { customRenderHook } from '../context/test-utils/test-utils';
-import type { DataClass } from '../data/dataclass';
-import { rowClassName, useUpdateOrder } from './ValidationRow';
-
-test('useUpdateOrder', () => {
-  const dataClass = {
-    fields: [{ name: 'field0' }, { name: 'field1' }, { name: 'field2' }, { name: 'field3' }, { name: 'field4' }]
-  } as DataClass;
-  let newDataClass = {} as DataClass;
-  const view = customRenderHook(() => useUpdateOrder(), {
-    wrapperProps: { appContext: { dataClass, setDataClass: dataClass => (newDataClass = dataClass) } }
-  });
-
-  const originalDataClass = structuredClone(dataClass);
-  view.result.current('0', '2');
-  expect(dataClass).toEqual(originalDataClass);
-
-  expect(newDataClass.fields).toEqual([{ name: 'field1' }, { name: 'field2' }, { name: 'field0' }, { name: 'field3' }, { name: 'field4' }]);
-
-  view.result.current('2', '4');
-  expect(newDataClass.fields).toEqual([{ name: 'field0' }, { name: 'field1' }, { name: 'field3' }, { name: 'field4' }, { name: 'field2' }]);
-
-  view.result.current('4', '0');
-  expect(newDataClass.fields).toEqual([{ name: 'field4' }, { name: 'field0' }, { name: 'field1' }, { name: 'field2' }, { name: 'field3' }]);
-});
+import { rowClassName } from './ValidationRow';
 
 test('rowClassName', () => {
   expect(rowClassName([{ variant: 'info' }, { variant: 'info' }, { variant: 'info' }])).toBeUndefined();

--- a/packages/dataclass-editor/src/master/ValidationRow.tsx
+++ b/packages/dataclass-editor/src/master/ValidationRow.tsx
@@ -1,18 +1,8 @@
-import { arraymove, MessageRow, ReorderRow, SelectRow, TableCell, type MessageData } from '@axonivy/ui-components';
+import { MessageRow, ReorderRow, SelectRow, TableCell, type MessageData } from '@axonivy/ui-components';
 import { flexRender, type Row } from '@tanstack/react-table';
-import { useAppContext } from '../context/AppContext';
 import type { DataClassField } from '../data/dataclass';
 import './ValidationRow.css';
 import { useValidation } from './useValidation';
-
-export const useUpdateOrder = () => {
-  const { dataClass, setDataClass } = useAppContext();
-  return (moveId: string, targetId: string) => {
-    const newDataClass = structuredClone(dataClass);
-    arraymove(newDataClass.fields, parseInt(moveId), parseInt(targetId));
-    setDataClass(newDataClass);
-  };
-};
 
 export const rowClassName = (messages: Array<MessageData>) => {
   if (messages.some(message => message.variant === 'error')) {
@@ -26,21 +16,35 @@ export const rowClassName = (messages: Array<MessageData>) => {
 type ValidationRowProps = {
   row: Row<DataClassField>;
   isReorderable: boolean;
+  updateOrder: (moveId: string, targetId: string) => void;
+  onClick: React.MouseEventHandler<HTMLTableRowElement>;
+  onDrag: React.DragEventHandler<HTMLTableRowElement>;
 };
 
-export const ValidationRow = ({ row, isReorderable }: ValidationRowProps) => {
-  const updateOrder = useUpdateOrder();
+export const ValidationRow = ({ row, isReorderable, updateOrder, onClick, onDrag }: ValidationRowProps) => {
   const messages = useValidation(row.original);
 
-  const RowComponent = isReorderable ? ReorderRow : SelectRow;
+  const tableCell = row
+    .getVisibleCells()
+    .map(cell => <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>);
+
+  const commonProps = {
+    id: row.index.toString(),
+    row: row,
+    className: rowClassName(messages),
+    onClick: onClick,
+    onDrag: onDrag
+  };
 
   return (
     <>
-      <RowComponent id={row.index.toString()} row={row} className={rowClassName(messages)} updateOrder={updateOrder}>
-        {row.getVisibleCells().map(cell => (
-          <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-        ))}
-      </RowComponent>
+      {isReorderable ? (
+        <ReorderRow {...commonProps} updateOrder={updateOrder}>
+          {tableCell}
+        </ReorderRow>
+      ) : (
+        <SelectRow {...commonProps}>{tableCell}</SelectRow>
+      )}
       {messages.map((message, index) => (
         <MessageRow key={index} columnCount={3} message={message} />
       ))}

--- a/packages/dataclass-editor/src/protocol/client-json-rpc.ts
+++ b/packages/dataclass-editor/src/protocol/client-json-rpc.ts
@@ -18,6 +18,7 @@ import type {
   RequestTypes,
   ValidationMessage
 } from './types';
+import type { DataClassField } from '../data/dataclass';
 
 export class ClientJsonRpc extends BaseRpcClient implements Client {
   protected onDataChangedEmitter = new Emitter<void>();
@@ -38,6 +39,10 @@ export class ClientJsonRpc extends BaseRpcClient implements Client {
 
   validate(context: DataContext): Promise<Array<ValidationMessage>> {
     return this.sendRequest('validate', context);
+  }
+
+  function(func: DataClassActionArgs): Promise<Array<DataClassField>> {
+    return this.sendRequest('function', func);
   }
 
   meta<TMeta extends keyof MetaRequestTypes>(path: TMeta, args: MetaRequestTypes[TMeta][0]): Promise<MetaRequestTypes[TMeta][1]> {

--- a/packages/dataclass-editor/src/protocol/types.ts
+++ b/packages/dataclass-editor/src/protocol/types.ts
@@ -1,12 +1,12 @@
-import type { DataClass } from '../data/dataclass';
+import type { DataClass, DataClassField } from '../data/dataclass';
 
 export type Data = { context: DataContext; data: DataClass };
 export type DataContext = { app: string; pmv: string; file: string };
 export type EditorProps = { context: DataContext; directSave?: boolean };
 export type SaveArgs = Data & { directSave?: boolean };
 export interface DataClassActionArgs {
-  actionId: 'openForm' | 'openProcess';
-  payload: string;
+  actionId: 'openForm' | 'openProcess' | 'combineFields';
+  payload: string | CombinePayload;
   context: DataContext;
 }
 
@@ -17,6 +17,7 @@ export interface RequestTypes extends MetaRequestTypes {
   data: [DataContext, Data];
   saveData: [Data, Array<ValidationMessage>];
   validate: [DataContext, Array<ValidationMessage>];
+  function: [DataClassActionArgs, Array<DataClassField>];
 }
 
 export interface NotificationTypes {
@@ -39,6 +40,7 @@ export interface Client {
   data(context: DataContext): Promise<Data>;
   saveData(saveArgs: SaveArgs): Promise<Array<ValidationMessage>>;
   validate(context: DataContext): Promise<Array<ValidationMessage>>;
+  function(func: DataClassActionArgs): Promise<Array<DataClassField>>;
 
   meta<TMeta extends keyof MetaRequestTypes>(path: TMeta, args: MetaRequestTypes[TMeta][0]): Promise<MetaRequestTypes[TMeta][1]>;
 
@@ -75,4 +77,8 @@ export interface DataclassType {
   name: string;
   packageName: string;
   path: string;
+}
+
+export interface CombinePayload {
+  fieldNames: string[];
 }


### PR DESCRIPTION
- Added multi-select functionality with ctrl-pressed to the DataClassContentTable.
- Users can now select, move, and delete multiple fields at once.
- Once multiple fields are selected, the Combine button is available.
- Backend implementation is still needed, but first frontend preparations for the new endpoint are in place.

![multiselect](https://github.com/user-attachments/assets/8bb27d77-6ed3-419e-ada5-e1c767cfb64e)
