### PR TITLE
XIVY-15045 Improve TypeBrowser and fix multiselect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,17 +66,17 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "12.0.0-next.344",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.0-next.344.tgz",
-      "integrity": "sha512-Cm6LiJYkRZDMBTlzVfocVB0fO3J+qmn+NbP3/ASSIRBsLVDJdxR9HEkDzgjElAbZO++hBg/RHRheQM5kbeShKA==",
+      "version": "12.0.0-next.358",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.0-next.358.tgz",
+      "integrity": "sha512-JMvcqLYu7Tk0CYS+nsN7TTh/F1iRimWCdyP9r4WDPDDmYGi1nt5hR5hl4dIFVHxeRl1odKe6jrinPOsv8T+zmQ==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0"
       }
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "12.0.0-next.344",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.0-next.344.tgz",
-      "integrity": "sha512-vEV9o61vaHdhCYsPRNbvjYDm5voWPYNkICP+W0ajuC0fRHYWlgZoynDyzNSijPJ9q/xZ0YQGp7Pb7223LFHjAA==",
+      "version": "12.0.0-next.358",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.0-next.358.tgz",
+      "integrity": "sha512-cu4hWQn/2B2jB24mdE/4A8NnDyiYzzxctPZc1ahdpJVWYnQk8Dx0cG2EDiKNwaCeTYbwYdrWan2rB40B8oIXCg==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.1",
         "@radix-ui/react-checkbox": "1.1.2",
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@axonivy/ui-icons": {
-      "version": "12.0.0-next.344",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.0-next.344.tgz",
-      "integrity": "sha512-fo15PPFenwF9WRuQvZW1K/e5uKfUejQ5Y+WRsFvIGrWf8dAVqesj8dhBVkHOaWgoSMDQkR/rml5yfURC/YFcdg=="
+      "version": "12.0.0-next.358",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.0-next.358.tgz",
+      "integrity": "sha512-gfscya1MV8gNXDMtoIIu95HM6uoSOEDf/ZPJyVrOowYvykz0EzMj3ptBdC2Ob0Z6XNS6k/wChzWb9H9/C/o5MQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
@@ -15282,9 +15282,9 @@
       "version": "12.0.0-next",
       "license": "Apache-2.0",
       "dependencies": {
-        "@axonivy/jsonrpc": "~12.0.0-next.344",
-        "@axonivy/ui-components": "~12.0.0-next.344",
-        "@axonivy/ui-icons": "~12.0.0-next.344",
+        "@axonivy/jsonrpc": "~12.0.0-next.358",
+        "@axonivy/ui-components": "~12.0.0-next.358",
+        "@axonivy/ui-icons": "~12.0.0-next.358",
         "@tanstack/react-query": "5.32.1",
         "@tanstack/react-query-devtools": "5.32.1",
         "react": "^18.2.0"

--- a/packages/dataclass-editor/package.json
+++ b/packages/dataclass-editor/package.json
@@ -17,9 +17,9 @@
   "types": "lib/index.d.ts",
   "main": "lib/editor.js",
   "dependencies": {
-    "@axonivy/jsonrpc": "~12.0.0-next.344",
-    "@axonivy/ui-components": "~12.0.0-next.344",
-    "@axonivy/ui-icons": "~12.0.0-next.344",
+    "@axonivy/jsonrpc": "~12.0.0-next.358",
+    "@axonivy/ui-components": "~12.0.0-next.358",
+    "@axonivy/ui-icons": "~12.0.0-next.358",
     "@tanstack/react-query": "5.32.1",
     "@tanstack/react-query-devtools": "5.32.1",
     "react": "^18.2.0"

--- a/packages/dataclass-editor/src/data/type-data.test.ts
+++ b/packages/dataclass-editor/src/data/type-data.test.ts
@@ -29,55 +29,57 @@ const allTypes: JavaType[] = [
 describe('typeData', () => {
   test('returns empty array if both input arrays are empty', () => {
     const result = typeData([], [], [], [], false);
-    expect(result).toEqual([]);
+    expect(result.length).toEqual(2);
   });
 
   test('returns sorted data class nodes when dataClasses are provided', () => {
     const result = typeData(dataClasses, [], [], [], false);
     expect(result).toHaveLength(2);
-    expect(result[0].value).toBe('ClassA');
-    expect(result[1].value).toBe('ClassB');
+    expect(result[0].children[0].value).toBe('ClassA');
+    expect(result[0].children[1].value).toBe('ClassB');
   });
 
   test('returns sorted non-Ivy type nodes when ivyTypes are provided', () => {
     const result = typeData([], nonIvyTypes, [], [], false);
     expect(result).toHaveLength(2);
-    expect(result[0].value).toBe('TypeC');
-    expect(result[1].value).toBe('TypeD');
+    expect(result[1].children[0].value).toBe('TypeC');
+    expect(result[1].children[1].value).toBe('TypeD');
   });
 
   test('returns combined sorted nodes from dataClasses and non-Ivy and Ivy types', () => {
     const result = typeData(dataClasses, [...nonIvyTypes, ...ivyTypes], [], [], false);
-    expect(result).toHaveLength(6);
-    expect(result[0].value).toBe('ClassA');
-    expect(result[1].value).toBe('ClassB');
-    expect(result[2].value).toBe('TypeB');
-    expect(result[3].value).toBe('TypeC');
-    expect(result[4].value).toBe('TypeD');
-    expect(result[5].value).toBe('IvyTypeA');
+    expect(result[0].children).toHaveLength(2);
+    expect(result[1].children).toHaveLength(4);
+    expect(result[0].children[0].value).toBe('ClassA');
+    expect(result[0].children[1].value).toBe('ClassB');
+    expect(result[1].children[0].value).toBe('TypeB');
+    expect(result[1].children[1].value).toBe('TypeC');
+    expect(result[1].children[2].value).toBe('TypeD');
+    expect(result[1].children[3].value).toBe('IvyTypeA');
   });
 
   test('correctly classifies and sorts Ivy and non-Ivy types', () => {
     const result = typeData(dataClasses, ivyTypes, [], [], false);
-    expect(result).toHaveLength(4);
-    expect(result[0].value).toBe('ClassA');
-    expect(result[1].value).toBe('ClassB');
-    expect(result[2].value).toBe('TypeB');
-    expect(result[3].value).toBe('IvyTypeA');
+    expect(result[0].children).toHaveLength(2);
+    expect(result[1].children).toHaveLength(2);
+    expect(result[0].children[0].value).toBe('ClassA');
+    expect(result[0].children[1].value).toBe('ClassB');
+    expect(result[1].children[0].value).toBe('TypeB');
+    expect(result[1].children[1].value).toBe('IvyTypeA');
   });
 
   test('returns nodes with correct icons', () => {
     const result = typeData(dataClasses, ivyTypes, [], [], false);
-    expect(result[0].icon).toBe(IvyIcons.LetterD);
-    expect(result[2].icon).toBe(IvyIcons.DataClass);
-    expect(result[3].icon).toBe(IvyIcons.Ivy);
+    expect(result[0].children[0].icon).toBe(IvyIcons.LetterD);
+    expect(result[1].children[0].icon).toBe(IvyIcons.Ivy);
+    expect(result[1].children[1].icon).toBe(IvyIcons.Ivy);
   });
 
   test('includes ownTypes if allTypesSearchActive is false', () => {
     const result = typeData([], [], ownTypes, [], false);
-    expect(result).toHaveLength(1);
-    expect(result[0].value).toBe('TypeE');
-    expect(result[0].icon).toBe(IvyIcons.DataClass);
+    expect(result).toHaveLength(3);
+    expect(result[2].children[0].value).toBe('TypeE');
+    expect(result[2].icon).toBe(IvyIcons.DataClass);
   });
 
   test('does not include ownTypes if allTypesSearchActive is true', () => {
@@ -106,11 +108,11 @@ describe('typeData', () => {
 
   test('sorts combined types correctly when allTypesSearchActive is false', () => {
     const result = typeData(dataClasses, ivyTypes, ownTypes, allTypes, false);
-    expect(result).toHaveLength(5);
-    expect(result[0].value).toBe('TypeE');
-    expect(result[1].value).toBe('ClassA');
-    expect(result[2].value).toBe('ClassB');
-    expect(result[3].value).toBe('TypeB');
-    expect(result[4].value).toBe('IvyTypeA');
+    expect(result).toHaveLength(3);
+    expect(result[2].children[0].value).toBe('TypeE');
+    expect(result[0].children[0].value).toBe('ClassA');
+    expect(result[0].children[1].value).toBe('ClassB');
+    expect(result[1].children[0].value).toBe('TypeB');
+    expect(result[1].children[1].value).toBe('IvyTypeA');
   });
 });

--- a/packages/dataclass-editor/src/data/type-data.ts
+++ b/packages/dataclass-editor/src/data/type-data.ts
@@ -26,7 +26,7 @@ export const typeData = (
   const dataClassNodes = sortedDataClasses.map(dataClass =>
     createNode({ ...dataClass, simpleName: dataClass.name }, IvyIcons.LetterD, dataClass)
   );
-  const nonIvyTypeNodes = sortedNonIvyTypes.map(javaType => createNode(javaType, IvyIcons.DataClass));
+  const nonIvyTypeNodes = sortedNonIvyTypes.map(javaType => createNode(javaType, IvyIcons.Ivy));
   const ivyTypeNodes = sortedIvyOnlyTypes.map(javaType => createNode(javaType, IvyIcons.Ivy));
   const ownTypeNodes = filteredOwnTypes.map(javaType => createNode(javaType, IvyIcons.DataClass));
   const allTypeNodes = filteredAllTypes.map(type => {
@@ -38,13 +38,41 @@ export const typeData = (
     return createNode(type, icon);
   });
 
-  const combinedTypes = [
-    ...(allTypesSearchActive ? [] : ownTypeNodes),
-    ...dataClassNodes,
-    ...nonIvyTypeNodes,
-    ...ivyTypeNodes,
-    ...(allTypesSearchActive ? allTypeNodes : [])
-  ];
+  const combinedTypes = allTypesSearchActive
+    ? [...dataClassNodes, ...nonIvyTypeNodes, ...ivyTypeNodes, ...allTypeNodes]
+    : [
+        {
+          value: 'Data Classes',
+          info: '',
+          icon: IvyIcons.LetterD,
+          data: undefined,
+          notSelectable: true,
+          children: dataClassNodes,
+          isLoaded: true
+        },
+        {
+          value: 'Ivy Script Data Types',
+          info: '',
+          icon: IvyIcons.Ivy,
+          data: undefined,
+          notSelectable: true,
+          children: [...nonIvyTypeNodes, ...ivyTypeNodes],
+          isLoaded: true
+        },
+        ...(ownTypes.length > 0
+          ? [
+              {
+                value: 'Own Types',
+                info: '',
+                icon: IvyIcons.DataClass,
+                data: undefined,
+                notSelectable: true,
+                children: ownTypeNodes,
+                isLoaded: true
+              }
+            ]
+          : [])
+      ];
 
   const sortedCombinedTypes =
     allTypesSearchActive && (filteredAllTypes.length > 0 || filteredOwnTypes.length > 0)

--- a/packages/dataclass-editor/src/detail/field/ComboboxFieldWithTypeBrowser.tsx
+++ b/packages/dataclass-editor/src/detail/field/ComboboxFieldWithTypeBrowser.tsx
@@ -32,7 +32,7 @@ export const ComboboxFieldWithTypeBrowser = ({ value, onChange, message }: Input
   const [typeAsList, setTypeAsList] = useState<boolean>(false);
   const dataClasses = useMeta('meta/scripting/dataClasses', context, []).data;
   const ivyTypes = useMeta('meta/scripting/ivyTypes', undefined, []).data;
-  const types = useMemo(() => typeData(dataClasses, ivyTypes, [], [], false), [dataClasses, ivyTypes]);
+  const types = useMemo(() => typeData(dataClasses, ivyTypes, [], [], true), [dataClasses, ivyTypes]);
 
   const typeAsListChange = (change: boolean) => {
     setTypeAsList(!typeAsList);
@@ -64,6 +64,9 @@ export const ComboboxFieldWithTypeBrowser = ({ value, onChange, message }: Input
               } else {
                 onChange(value);
               }
+              if (!value.startsWith('List<') && !value.endsWith('>')) {
+                setTypeAsList(false);
+              }
             }}
             value={value}
             options={types}
@@ -83,6 +86,7 @@ export const ComboboxFieldWithTypeBrowser = ({ value, onChange, message }: Input
               setTypeAsList(true);
             }
           }}
+          value={value}
           close={() => setOpen(false)}
         />
       </DialogContent>

--- a/packages/dataclass-editor/src/detail/field/InputFieldWithTypeBrowser.tsx
+++ b/packages/dataclass-editor/src/detail/field/InputFieldWithTypeBrowser.tsx
@@ -22,7 +22,7 @@ export const InputFieldWithTypeBrowser = ({ value, onChange, message }: InputFie
         </InputGroup>
       </BasicField>
       <DialogContent style={{ height: '80vh' }}>
-        <Browser onChange={onChange} close={() => setOpen(false)} />
+        <Browser onChange={onChange} close={() => setOpen(false)} value={value} />
       </DialogContent>
     </Dialog>
   );

--- a/packages/dataclass-editor/src/detail/field/browser/Browser.tsx
+++ b/packages/dataclass-editor/src/detail/field/browser/Browser.tsx
@@ -3,11 +3,12 @@ import { useTypeBrowser } from './useTypeBrowser';
 
 type BrowserProps = {
   onChange: (value: string) => void;
+  value: string;
   close: () => void;
 };
 
-export const Browser = ({ onChange, close }: BrowserProps) => {
-  const typeBrowser = useTypeBrowser();
+export const Browser = ({ onChange, close, value }: BrowserProps) => {
+  const typeBrowser = useTypeBrowser(value);
   return (
     <BrowsersView
       browsers={[typeBrowser]}

--- a/packages/dataclass-editor/src/detail/field/browser/useTypeBrowser.tsx
+++ b/packages/dataclass-editor/src/detail/field/browser/useTypeBrowser.tsx
@@ -6,11 +6,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { useMeta } from '../../../context/useMeta';
 import { typeData } from '../../../data/type-data';
 import { useAppContext } from '../../../context/AppContext';
+import { getInitialSelectState, getInitialTypeAsListState, getInitialValue } from '../../../utils/browser/typeBrowserUtils';
 
-export const useTypeBrowser = (): Browser => {
+export const useTypeBrowser = (value: string): Browser => {
   const { context } = useAppContext();
   const [allTypesSearchActive, setAllTypesSearchActive] = useState<boolean>(false);
-  const [typeAsList, setTypeAsList] = useState<boolean>(false);
 
   const dataClasses = useMeta('meta/scripting/dataClasses', context, []).data;
   const ivyTypes = useMeta('meta/scripting/ivyTypes', undefined, []).data;
@@ -25,12 +25,26 @@ export const useTypeBrowser = (): Browser => {
     () => typeData(dataClasses, ivyTypes, ownTypes, allDatatypes, allTypesSearchActive),
     [allDatatypes, allTypesSearchActive, dataClasses, ivyTypes, ownTypes]
   );
-  const typesList = useBrowser(types);
-  console.log(context);
+
+  const [typeAsList, setTypeAsList] = useState<boolean>(getInitialTypeAsListState(types, getInitialValue(value)));
+
+  const typesList = useBrowser(types, {
+    expandedState:
+      metaFilter.length > 0
+        ? true
+        : {
+            '0': dataClasses.some(dataclass => dataclass.fullQualifiedName === getInitialValue(value).value),
+            '1': ivyTypes.some(ivyType => ivyType.simpleName === getInitialValue(value).value)
+          },
+    initialSelecteState: getInitialSelectState(allTypesSearchActive, types, getInitialValue(value))
+  });
 
   useEffect(() => {
     setMetaFilter(typesList.globalFilter.filter);
-  }, [allTypesSearchActive, typesList.globalFilter.filter]);
+    if (typesList.globalFilter.filter.length > 0) {
+      typesList.table.setExpanded(true);
+    }
+  }, [allTypesSearchActive, typesList.globalFilter.filter, typesList.table]);
 
   return {
     name: 'Type',

--- a/packages/dataclass-editor/src/master/DataClassMasterContent.tsx
+++ b/packages/dataclass-editor/src/master/DataClassMasterContent.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   deleteAllSelectedRows,
   Flex,
-  handleMultiSelectOnCtrlRowClick,
   indexOf,
   Message,
   ReorderHandleWrapper,
@@ -20,6 +19,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  useMultiSelectRow,
   useReadonly,
   useTableSelect,
   useTableSort
@@ -108,6 +108,7 @@ export const DataClassMasterContent = () => {
     }
   });
   useUpdateSelection(table);
+  const { handleMultiSelectOnRow } = useMultiSelectRow(table);
 
   const deleteField = () => {
     const { newData: newFields, selection } = deleteAllSelectedRows(table, dataClass.fields);
@@ -194,7 +195,7 @@ export const DataClassMasterContent = () => {
                 row={row}
                 isReorderable={table.getState().sorting.length === 0}
                 onDrag={() => handleRowDrag(row)}
-                onClick={event => handleMultiSelectOnCtrlRowClick(table, row, event)}
+                onClick={event => handleMultiSelectOnRow(row, event)}
                 updateOrder={updateOrder}
               />
             ))}

--- a/packages/dataclass-editor/src/utils/browser/typeBrowserUtils.test.ts
+++ b/packages/dataclass-editor/src/utils/browser/typeBrowserUtils.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect } from 'vitest';
+import { getInitialSelectState, getInitialTypeAsListState, getInitialValue } from './typeBrowserUtils';
+import type { BrowserNode } from '@axonivy/ui-components';
+import type { DataclassType } from '../../protocol/types';
+import { IvyIcons } from '@axonivy/ui-icons';
+
+describe('getInitialValue', () => {
+  test('return value as list when input is in List<> format', () => {
+    const result = getInitialValue('List<ExampleType>');
+    expect(result).toEqual({ value: 'ExampleType', asList: true });
+  });
+
+  test('return value and asList false when input is not in List<> format', () => {
+    const result = getInitialValue('SingleType');
+    expect(result).toEqual({ value: 'SingleType', asList: false });
+  });
+
+  test('return value and asList false for empty string', () => {
+    const result = getInitialValue('');
+    expect(result).toEqual({ value: '', asList: false });
+  });
+});
+
+describe('getInitialTypeAsListState', () => {
+  const types: Array<BrowserNode<DataclassType>> = [
+    {
+      value: 'DataClass',
+      info: 'DataClassInfo',
+      icon: IvyIcons.LetterD,
+      children: [
+        { value: 'ExampleDataClass', info: 'Info1', icon: IvyIcons.LetterD, children: [] },
+        { value: 'AnotherDataClass', info: 'Info2', icon: IvyIcons.LetterD, children: [] }
+      ]
+    },
+    {
+      value: 'IvyType',
+      info: 'IvyTypeInfo',
+      icon: IvyIcons.Ivy,
+      children: [
+        { value: 'ExampleType', info: 'Info3', icon: IvyIcons.Ivy, children: [] },
+        { value: 'DifferentType', info: 'Info4', icon: IvyIcons.Ivy, children: [] }
+      ]
+    }
+  ];
+
+  test('return true if the value is found in Ivy types', () => {
+    const value = { value: 'ExampleType', asList: true };
+    const result = getInitialTypeAsListState(types, value);
+    expect(result).toBe(true);
+  });
+
+  test('return true if the value is found in DataClass types', () => {
+    const value = { value: 'Info1.ExampleDataClass', asList: true };
+    const result = getInitialTypeAsListState(types, value);
+    expect(result).toBe(true);
+  });
+
+  test('return false if the value is not found in either type', () => {
+    const value = { value: 'NonExistentType', asList: true };
+    const result = getInitialTypeAsListState(types, value);
+    expect(result).toBe(false);
+  });
+
+  test('return false if asList is false', () => {
+    const value = { value: 'ExampleDataClass', asList: false };
+    const result = getInitialTypeAsListState(types, value);
+    expect(result).toBe(false);
+  });
+});
+
+describe('getInitialSelectState', () => {
+  const types: Array<BrowserNode<DataclassType>> = [
+    {
+      value: 'DataClass',
+      info: 'DataClassInfo',
+      icon: IvyIcons.LetterD,
+      children: [{ value: 'ExampleDataClass', info: 'Info1', icon: IvyIcons.LetterD, children: [] }]
+    },
+    {
+      value: 'IvyType',
+      info: 'IvyTypeInfo',
+      icon: IvyIcons.Ivy,
+      children: [{ value: 'ExampleType', info: 'Info2', icon: IvyIcons.Ivy, children: [] }]
+    }
+  ];
+
+  test('return selected row id for IvyType if found', () => {
+    const value = { value: 'ExampleType', asList: false };
+    const result = getInitialSelectState(false, types, value);
+    expect(result).toEqual({ '1.0': true }); // index of ExampleType in IvyType children
+  });
+
+  test('return selected row id for DataClass if found', () => {
+    const value = { value: 'Info1.ExampleDataClass', asList: false };
+    const result = getInitialSelectState(false, types, value);
+    expect(result).toEqual({ '0.0': true }); // index of ExampleDataClass in DataClass children
+  });
+
+  test('return empty object if value is not found in either type', () => {
+    const value = { value: 'NonExistentType', asList: false };
+    const result = getInitialSelectState(false, types, value);
+    expect(result).toEqual({});
+  });
+
+  test('return empty object if allTypesSearchActive is true', () => {
+    const value = { value: 'ExampleType', asList: false };
+    const result = getInitialSelectState(true, types, value);
+    expect(result).toEqual({});
+  });
+});

--- a/packages/dataclass-editor/src/utils/browser/typeBrowserUtils.ts
+++ b/packages/dataclass-editor/src/utils/browser/typeBrowserUtils.ts
@@ -1,0 +1,44 @@
+import type { BrowserNode } from '@axonivy/ui-components';
+import type { DataclassType } from '../../protocol/types';
+import { type RowSelectionState } from '@tanstack/react-table';
+
+type InitialTypeBrowserValue = {
+  value: string;
+  asList: boolean;
+};
+
+export const getInitialValue = (value: string): InitialTypeBrowserValue => {
+  if (value.startsWith('List<') && value.endsWith('>')) {
+    const content = value.slice(5, -1);
+    return { value: content, asList: true };
+  } else {
+    return { value, asList: false };
+  }
+};
+export const getInitialTypeAsListState = (types: Array<BrowserNode<DataclassType>>, value: InitialTypeBrowserValue) => {
+  if (value.asList) {
+    return (
+      types[1].children.some(ivyType => ivyType.value === value.value) ||
+      types[0].children.some(dataclass => dataclass.info + '.' + dataclass.value === value.value)
+    );
+  }
+  return false;
+};
+
+export const getInitialSelectState = (
+  allTypesSearchActive: boolean,
+  types: Array<BrowserNode<DataclassType>>,
+  value: InitialTypeBrowserValue
+): RowSelectionState => {
+  if (!allTypesSearchActive) {
+    const ivyTypeIndex = types[1].children.findIndex(ivyType => ivyType.value === value.value);
+    if (ivyTypeIndex !== -1) {
+      return { [`1.${ivyTypeIndex}`]: true };
+    }
+    const dataClassIndex = types[0].children.findIndex(dataclass => dataclass.info + '.' + dataclass.value === value.value);
+    if (dataClassIndex !== -1) {
+      return { [`0.${dataClassIndex}`]: true };
+    }
+  }
+  return {};
+};


### PR DESCRIPTION
- Added multi-select functionality (range selection) using Shift or Ctrl+Shift.
- Enhanced Type Browser:
  - When "Search Over All Types" is **not** active, types are grouped into Data Classes and IvyScript Data Types (both are close by default).
  - If a type is already defined in the Type field when the browser is opened, it will be automatically open the group and select the type (if present). If it is a list type, the "Type as List" checkbox will also be pre-selected.

![typeBrowserimp](https://github.com/user-attachments/assets/fd2baf0f-3439-4b14-8e56-4ca9710bf139)
