### PR TITLE
XIVY-15045 Fix initialSelectState of TypeBrowser

### DIFF
--- a/packages/dataclass-editor/src/data/type-data.ts
+++ b/packages/dataclass-editor/src/data/type-data.ts
@@ -37,7 +37,6 @@ export const typeData = (
       : IvyIcons.DataClass;
     return createNode(type, icon);
   });
-
   const combinedTypes = allTypesSearchActive
     ? [...dataClassNodes, ...nonIvyTypeNodes, ...ivyTypeNodes, ...allTypeNodes]
     : [
@@ -59,7 +58,7 @@ export const typeData = (
           children: [...nonIvyTypeNodes, ...ivyTypeNodes],
           isLoaded: true
         },
-        ...(ownTypes.length > 0
+        ...(ownTypeNodes.length > 0
           ? [
               {
                 value: 'Own Types',

--- a/packages/dataclass-editor/src/detail/field/browser/useTypeBrowser.tsx
+++ b/packages/dataclass-editor/src/detail/field/browser/useTypeBrowser.tsx
@@ -6,17 +6,25 @@ import { useEffect, useMemo, useState } from 'react';
 import { useMeta } from '../../../context/useMeta';
 import { typeData } from '../../../data/type-data';
 import { useAppContext } from '../../../context/AppContext';
-import { getInitialSelectState, getInitialTypeAsListState, getInitialValue } from '../../../utils/browser/typeBrowserUtils';
+import {
+  getInitialExpandState,
+  getInitialSelectState,
+  getInitialTypeAsListState,
+  getInitialValue
+} from '../../../utils/browser/typeBrowserUtils';
 
 export const useTypeBrowser = (value: string): Browser => {
   const { context } = useAppContext();
-  const [allTypesSearchActive, setAllTypesSearchActive] = useState<boolean>(false);
+  const [allTypesSearchActive, setAllTypesSearchActive] = useState(false);
+  const [initialState, setInitialState] = useState(true);
 
   const dataClasses = useMeta('meta/scripting/dataClasses', context, []).data;
   const ivyTypes = useMeta('meta/scripting/ivyTypes', undefined, []).data;
 
   const [metaFilter, setMetaFilter] = useState('');
-  const ownTypes = useMeta('meta/scripting/ownTypes', { context, limit: 50, type: metaFilter }, [], { disable: allTypesSearchActive }).data;
+  const ownTypes = useMeta('meta/scripting/ownTypes', { context, limit: 50, type: metaFilter }, [], {
+    disable: allTypesSearchActive
+  }).data;
   const allDatatypes = useMeta('meta/scripting/allTypes', { context, limit: 150, type: metaFilter }, [], {
     disable: !allTypesSearchActive
   }).data;
@@ -28,21 +36,23 @@ export const useTypeBrowser = (value: string): Browser => {
 
   const [typeAsList, setTypeAsList] = useState<boolean>(getInitialTypeAsListState(types, getInitialValue(value)));
 
-  const typesList = useBrowser(types, {
-    expandedState:
-      metaFilter.length > 0
-        ? true
-        : {
-            '0': dataClasses.some(dataclass => dataclass.fullQualifiedName === getInitialValue(value).value),
-            '1': ivyTypes.some(ivyType => ivyType.simpleName === getInitialValue(value).value)
-          },
-    initialSelecteState: getInitialSelectState(allTypesSearchActive, types, getInitialValue(value))
-  });
+  const typesList = useBrowser(types);
+
+  useEffect(() => {
+    if (!allTypesSearchActive && initialState) {
+      const newExpandedState = getInitialExpandState(types, getInitialValue(value).value);
+      typesList.table.setExpanded(newExpandedState);
+
+      const newSelectedState = getInitialSelectState(allTypesSearchActive, types, getInitialValue(value));
+      typesList.table.setRowSelection(newSelectedState);
+    }
+  }, [allTypesSearchActive, value, typesList.table, types, initialState]);
 
   useEffect(() => {
     setMetaFilter(typesList.globalFilter.filter);
-    if (typesList.globalFilter.filter.length > 0) {
+    if (typesList.globalFilter.filter.length > 0 && !allTypesSearchActive) {
       typesList.table.setExpanded(true);
+      setInitialState(false);
     }
   }, [allTypesSearchActive, typesList.globalFilter.filter, typesList.table]);
 
@@ -54,7 +64,10 @@ export const useTypeBrowser = (value: string): Browser => {
       <BasicCheckbox
         label='Search over all Types'
         checked={allTypesSearchActive}
-        onCheckedChange={() => setAllTypesSearchActive(!allTypesSearchActive)}
+        onCheckedChange={() => {
+          setAllTypesSearchActive(!allTypesSearchActive);
+          setInitialState(false);
+        }}
       />
     ) : undefined,
     footer: <BasicCheckbox label='Type as List' checked={typeAsList} onCheckedChange={() => setTypeAsList(!typeAsList)} />,

--- a/packages/dataclass-editor/src/utils/browser/typeBrowserUtils.test.ts
+++ b/packages/dataclass-editor/src/utils/browser/typeBrowserUtils.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect } from 'vitest';
-import { getInitialSelectState, getInitialTypeAsListState, getInitialValue } from './typeBrowserUtils';
+import { getInitialExpandState, getInitialSelectState, getInitialTypeAsListState, getInitialValue } from './typeBrowserUtils';
 import type { BrowserNode } from '@axonivy/ui-components';
 import type { DataclassType } from '../../protocol/types';
 import { IvyIcons } from '@axonivy/ui-icons';
+
+const types: Array<BrowserNode<DataclassType>> = [
+  {
+    value: 'DataClass',
+    info: 'DataClassInfo',
+    icon: IvyIcons.LetterD,
+    children: [
+      { value: 'ExampleDataClass', info: 'Info1', icon: IvyIcons.LetterD, children: [] },
+      { value: 'AnotherDataClass', info: 'Info2', icon: IvyIcons.LetterD, children: [] }
+    ]
+  },
+  {
+    value: 'IvyType',
+    info: 'IvyTypeInfo',
+    icon: IvyIcons.Ivy,
+    children: [
+      { value: 'ExampleType', info: 'Info3', icon: IvyIcons.Ivy, children: [] },
+      { value: 'DifferentType', info: 'Info4', icon: IvyIcons.Ivy, children: [] }
+    ]
+  }
+];
 
 describe('getInitialValue', () => {
   test('return value as list when input is in List<> format', () => {
@@ -22,27 +43,6 @@ describe('getInitialValue', () => {
 });
 
 describe('getInitialTypeAsListState', () => {
-  const types: Array<BrowserNode<DataclassType>> = [
-    {
-      value: 'DataClass',
-      info: 'DataClassInfo',
-      icon: IvyIcons.LetterD,
-      children: [
-        { value: 'ExampleDataClass', info: 'Info1', icon: IvyIcons.LetterD, children: [] },
-        { value: 'AnotherDataClass', info: 'Info2', icon: IvyIcons.LetterD, children: [] }
-      ]
-    },
-    {
-      value: 'IvyType',
-      info: 'IvyTypeInfo',
-      icon: IvyIcons.Ivy,
-      children: [
-        { value: 'ExampleType', info: 'Info3', icon: IvyIcons.Ivy, children: [] },
-        { value: 'DifferentType', info: 'Info4', icon: IvyIcons.Ivy, children: [] }
-      ]
-    }
-  ];
-
   test('return true if the value is found in Ivy types', () => {
     const value = { value: 'ExampleType', asList: true };
     const result = getInitialTypeAsListState(types, value);
@@ -69,31 +69,16 @@ describe('getInitialTypeAsListState', () => {
 });
 
 describe('getInitialSelectState', () => {
-  const types: Array<BrowserNode<DataclassType>> = [
-    {
-      value: 'DataClass',
-      info: 'DataClassInfo',
-      icon: IvyIcons.LetterD,
-      children: [{ value: 'ExampleDataClass', info: 'Info1', icon: IvyIcons.LetterD, children: [] }]
-    },
-    {
-      value: 'IvyType',
-      info: 'IvyTypeInfo',
-      icon: IvyIcons.Ivy,
-      children: [{ value: 'ExampleType', info: 'Info2', icon: IvyIcons.Ivy, children: [] }]
-    }
-  ];
-
   test('return selected row id for IvyType if found', () => {
     const value = { value: 'ExampleType', asList: false };
     const result = getInitialSelectState(false, types, value);
-    expect(result).toEqual({ '1.0': true }); // index of ExampleType in IvyType children
+    expect(result).toEqual({ '1.0': true });
   });
 
   test('return selected row id for DataClass if found', () => {
     const value = { value: 'Info1.ExampleDataClass', asList: false };
     const result = getInitialSelectState(false, types, value);
-    expect(result).toEqual({ '0.0': true }); // index of ExampleDataClass in DataClass children
+    expect(result).toEqual({ '0.0': true });
   });
 
   test('return empty object if value is not found in either type', () => {
@@ -105,6 +90,38 @@ describe('getInitialSelectState', () => {
   test('return empty object if allTypesSearchActive is true', () => {
     const value = { value: 'ExampleType', asList: false };
     const result = getInitialSelectState(true, types, value);
+    expect(result).toEqual({});
+  });
+});
+
+describe('getInitialExpandState', () => {
+  test('return expanded state with true for DataClass if value is found in DataClass types', () => {
+    const result = getInitialExpandState(types, 'Info1.ExampleDataClass');
+    expect(result).toEqual({
+      '0': true,
+      '1': false
+    });
+  });
+
+  test('return expanded state with true for IvyType if value is found in Ivy types', () => {
+    const result = getInitialExpandState(types, 'ExampleType');
+    expect(result).toEqual({
+      '0': false,
+      '1': true
+    });
+  });
+
+  test('return expanded state with all false if value is not found in either type', () => {
+    const result = getInitialExpandState(types, 'NonExistentType');
+    expect(result).toEqual({
+      '0': false,
+      '1': false
+    });
+  });
+
+  test('return expanded state with all false if no types are present', () => {
+    const emptyTypes: Array<BrowserNode<DataclassType>> = [];
+    const result = getInitialExpandState(emptyTypes, 'ExampleType');
     expect(result).toEqual({});
   });
 });

--- a/packages/dataclass-editor/src/utils/browser/typeBrowserUtils.ts
+++ b/packages/dataclass-editor/src/utils/browser/typeBrowserUtils.ts
@@ -39,6 +39,25 @@ export const getInitialSelectState = (
     if (dataClassIndex !== -1) {
       return { [`0.${dataClassIndex}`]: true };
     }
+    if (types.length === 3) {
+      const ownTypesIndex = types[2].children.findIndex(ownTypes => ownTypes.info + '.' + ownTypes.value === value.value);
+      if (ownTypesIndex !== -1) {
+        return { [`2.${ownTypesIndex}`]: true };
+      }
+    }
+  }
+  return {};
+};
+
+export const getInitialExpandState = (types: Array<BrowserNode<DataclassType>>, value: string) => {
+  if (types.length >= 2) {
+    return {
+      '0': types[0].children.some(dataclass => dataclass.info + '.' + dataclass.value === value),
+      '1': types[1].children.some(ivyType => ivyType.value === value),
+      ...(types.length === 3 && {
+        '2': types[2].children.some(ownType => ownType.info + '.' + ownType.value === value)
+      })
+    };
   }
   return {};
 };


### PR DESCRIPTION
I've now moved the entire initial selection stuff into a useEffect hook rather than directly into the useBrowser hook to ensure the correct row is selected as soon as the data is available. This works quite well, and the inner part of the hook doesn't get called too often.

![pervInitialSelectStateTypeBrowser](https://github.com/user-attachments/assets/efd615a7-2d17-4737-bdf5-1389da2a7f99)
