### PR TITLE
Revert "Update dependency typescript to ~5.8.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/node": "^22.10.7",
         "lerna": "^8.1.9",
         "rimraf": "^6.0.1",
-        "typescript": "~5.8.0",
+        "typescript": "~5.7.3",
         "typescript-cp": "^0.1.9"
       },
       "engines": {
@@ -31,8 +31,8 @@
         "@axonivy/jsonrpc": "~13.1.0-next.552",
         "@axonivy/ui-components": "~13.1.0-next.552",
         "@axonivy/ui-icons": "~13.1.0-next.552",
-        "@tanstack/react-query": "^5.64",
-        "@tanstack/react-query-devtools": "^5.64",
+        "@tanstack/react-query": "^5.66.11",
+        "@tanstack/react-query-devtools": "^5.66.11",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -2066,20 +2066,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -14951,9 +14937,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^22.10.7",
     "lerna": "^8.1.9",
     "rimraf": "^6.0.1",
-    "typescript": "~5.8.0",
+    "typescript": "~5.7.3",
     "typescript-cp": "^0.1.9"
   },
   "workspaces": [


### PR DESCRIPTION
This reverts commit d859fb548860fd783b040c7a2db96a86ce6e63a7.

Need to wait for a new version of `@typescript-eslint/eslint-plugin` first.
