### PR TITLE
XIVY-17228 Type browser all types check box always visible

### DIFF
--- a/packages/dataclass-editor/src/detail/field/browser/useTypeBrowser.tsx
+++ b/packages/dataclass-editor/src/detail/field/browser/useTypeBrowser.tsx
@@ -59,7 +59,7 @@ export const useTypeBrowser = (value: string): Browser => {
     name: t('label.type'),
     icon: IvyIcons.DataClass,
     browser: typesList,
-    header: !context.file.includes('/neo') ? (
+    header: (
       <BasicCheckbox
         label={t('browser.searchAllTypes')}
         checked={allTypesSearchActive}
@@ -68,7 +68,7 @@ export const useTypeBrowser = (value: string): Browser => {
           setInitialState(false);
         }}
       />
-    ) : undefined,
+    ),
     footer: <BasicCheckbox label={t('browser.typeAsList')} checked={typeAsList} onCheckedChange={() => setTypeAsList(!typeAsList)} />,
     infoProvider: row => typeBrowserApply(row?.original as BrowserNode<DataclassType>, ivyTypes, typeAsList),
     applyModifier: row => ({ value: typeBrowserApply(row?.original as BrowserNode<DataclassType>, ivyTypes, typeAsList) })


### PR DESCRIPTION
IMO it is fine to just show this checkbox. 
If active the type browser changes to a flat list, which does not return all types on neo, but as soon as we have jdt or whatever on the engine we do not have to change here anything...


This gif is from current neo:
![Screen Recording 2025-10-06 at 13 05 44](https://github.com/user-attachments/assets/004944f7-f85e-4015-ac72-40cbe835cfe4)
