### PR TITLE
Use Axon Ivy internal dist-tags

### DIFF
--- a/.ivy/raise-deps.sh
+++ b/.ivy/raise-deps.sh
@@ -7,18 +7,19 @@ if [ -z "$1" ]; then
 fi
 
 VERSION="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/version-helper.sh"
+
+NEXT_VERSION="$(to_next_version "$VERSION")"
+NEXT_TAG="$(to_next_tag "$VERSION")"
 
 update_version() {
-  local version="${1/SNAPSHOT/next}"
-  sed -i -E "s/(\"@axonivy[^\"]*\": \"(workspace:)?)[^\"]*(\")/\1~$version\3/" "$2"
+  sed -i -E \
+    -e "s/(\"@axonivy[^\"]*\": \"(workspace:)?)~[0-9]+\.[0-9]+\.[0-9]+-next(\.[0-9]+\.[0-9A-Za-z]+)?(\")/\1~$NEXT_VERSION\4/" \
+    -e "s/(\"@axonivy[^\"]*\": \")next-[0-9]+\.[0-9]+\.[0-9]+(\")/\1$NEXT_TAG\2/" \
+    "$1"
 }
 
 for pkg in packages/*/package.json integrations/*/package.json package.json; do
-  update_version "$VERSION" "$pkg"
+  update_version "$pkg"
 done
-
-pnpm run update:axonivy:next
-
-if [ "$DRY_RUN" = false ]; then
-  pnpm install --no-frozen-lockfile
-fi

--- a/.ivy/raise-version.sh
+++ b/.ivy/raise-version.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 set -e
 
-mvn --batch-mode -f integrations/standalone/pom.xml versions:set versions:commit -DnewVersion=${1}
-mvn --batch-mode -f playwright/dataclass-test-project/pom.xml versions:set versions:commit -DnewVersion=${1}
-mvn --batch-mode -f playwright/tests/screenshots/pom.xml versions:set versions:commit -DnewVersion=${1}
+VERSION="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/version-helper.sh"
+
+NEXT_VERSION="$(to_next_version "$VERSION")"
+NEXT_TAG="$(to_next_tag "$VERSION")"
+
+mvn --batch-mode -f integrations/standalone/pom.xml versions:set versions:commit -DnewVersion="$VERSION"
+mvn --batch-mode -f playwright/dataclass-test-project/pom.xml versions:set versions:commit -DnewVersion="$VERSION"
+mvn --batch-mode -f playwright/tests/screenshots/pom.xml versions:set versions:commit -DnewVersion="$VERSION"
 
 pnpm install
-pnpm run raise:version ${1/-SNAPSHOT/-next}
+pnpm run raise:version "$NEXT_VERSION"
+sed -i -E "s/(--pre-dist-tag )next-[0-9]+\.[0-9]+\.[0-9]+/\1$NEXT_TAG/" package.json
 pnpm install --no-frozen-lockfile

--- a/.ivy/version-helper.sh
+++ b/.ivy/version-helper.sh
@@ -1,0 +1,7 @@
+to_next_version() {
+  echo "${1/SNAPSHOT/next}"
+}
+
+to_next_tag() {
+  echo "next-${1%-SNAPSHOT}"
+}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@axonivy:registry=https://npmjs-registry.ivyteam.ch/

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -15,9 +15,8 @@ pipeline {
         script {
           catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
             docker.build('node', '-f build/Dockerfile.node .').inside {
-              sh 'pnpm run update:axonivy:next'
-              sh 'pnpm install --no-frozen-lockfile && pnpm run package'
-              sh 'pnpm run check'
+              sh 'pnpm install && pnpm run update:axonivy:next'
+              sh 'pnpm run package && pnpm run check'
             }
           }
           archiveArtifacts artifacts: '**/integrations/standalone/build/**', allowEmptyArchive: true

--- a/build/integration/Jenkinsfile
+++ b/build/integration/Jenkinsfile
@@ -20,8 +20,8 @@ pipeline {
       steps {
         script {
           docker.build('node-webtest', '-f build/Dockerfile.playwright .').inside {
-            sh 'pnpm run update:axonivy:next'
-            sh 'pnpm install --no-frozen-lockfile && pnpm run package'
+            sh 'pnpm install && pnpm run update:axonivy:next'
+            sh 'pnpm run package'
             dir ('playwright/dataclass-test-project') {
               maven cmd: "-ntp clean verify -Dengine.page.url=${params.engineSource} -Dwebtest.cmd=webtest:${browser()}"
             }
@@ -44,7 +44,7 @@ pipeline {
             docker.build('node', '-f build/Dockerfile.node .').inside {
               def branchName = env.BRANCH_NAME.replace("/", "%252F")
               sh '''
-                pnpm install --no-frozen-lockfile
+                pnpm install
                 pnpm run protocol clean
 
                 artifacts="https://jenkins.ivyteam.io/job/core_json-schema/job/'''+branchName+'''/lastSuccessfulBuild/artifact"

--- a/build/screenshots/Jenkinsfile
+++ b/build/screenshots/Jenkinsfile
@@ -17,8 +17,8 @@ pipeline {
         script {
           catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
             docker.build('node-webtest', '-f build/Dockerfile.playwright .').inside {
-              sh 'pnpm run update:axonivy:next'
-              sh 'pnpm install --no-frozen-lockfile && pnpm run package'
+              sh 'pnpm install && pnpm run update:axonivy:next'
+              sh 'pnpm run package'
               sh 'pnpm run webtest:screenshot'
             }
           }

--- a/integrations/standalone/package.json
+++ b/integrations/standalone/package.json
@@ -5,9 +5,9 @@
   "dependencies": {
     "@axonivy/dataclass-editor": "workspace:~",
     "@axonivy/dataclass-editor-protocol": "workspace:~",
-    "@axonivy/jsonrpc": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-components": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/jsonrpc": "next-12.0.16",
+    "@axonivy/ui-components": "next-12.0.16",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-query-devtools": "^5.100.14",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "test:ci": "pnpm run --filter @axonivy/dataclass-editor test:ci",
     "webtest": "pnpm run --filter @axonivy/dataclass-editor-playwright webtest",
     "webtest:screenshot": "pnpm run --filter @axonivy/dataclass-editor-playwright webtest:screenshots",
-    "update:axonivy:next": "npx --yes npm-check-updates @axonivy* -w -c 0 -t semver -u",
+    "update:axonivy:next": "pnpm update -r @axonivy",
     "raise:version": "lerna version --no-git-tag-version --no-push --ignore-scripts --exact --yes",
-    "publish:next": "lerna publish --exact --canary --preid next --tag-version-prefix beta --pre-dist-tag next --no-git-tag-version --no-push --ignore-scripts --yes"
+    "publish:next": "lerna publish --exact --canary --preid next --tag-version-prefix beta --pre-dist-tag next-12.0.16 --no-git-tag-version --no-push --ignore-scripts --yes"
   },
   "devDependencies": {
-    "@axonivy/eslint-config": "~12.0.16-next.762.6b30854",
+    "@axonivy/eslint-config": "next-12.0.16",
     "@lerna-lite/cli": "^4.11.5",
     "@lerna-lite/publish": "^4.11.5",
     "@lerna-lite/version": "^4.11.5",

--- a/packages/dataclass-editor/package.json
+++ b/packages/dataclass-editor/package.json
@@ -28,9 +28,9 @@
     "react": "^18.2 || ^19.0"
   },
   "devDependencies": {
-    "@axonivy/jsonrpc": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-components": "~12.0.16-next.762.6b30854",
-    "@axonivy/ui-icons": "~12.0.16-next.762.6b30854",
+    "@axonivy/jsonrpc": "next-12.0.16",
+    "@axonivy/ui-components": "next-12.0.16",
+    "@axonivy/ui-icons": "next-12.0.16",
     "@tanstack/react-table": "^8.21.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@axonivy/eslint-config':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(typescript@5.9.3)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(typescript@5.9.3)
       '@lerna-lite/cli':
         specifier: ^4.11.5
         version: 4.11.5(@lerna-lite/publish@4.11.5(@types/node@24.13.0)(conventional-commits-filter@5.0.0))(@lerna-lite/version@4.11.5(@lerna-lite/publish@4.11.5(@types/node@24.13.0)(conventional-commits-filter@5.0.0))(@types/node@24.13.0)(conventional-commits-filter@5.0.0))(@types/node@24.13.0)
@@ -39,14 +39,14 @@ importers:
         specifier: workspace:~
         version: link:../../packages/protocol
       '@axonivy/jsonrpc':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@axonivy/ui-components':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@tanstack/react-query':
         specifier: ^5.100.14
         version: 5.101.0(react@18.3.1)
@@ -86,14 +86,14 @@ importers:
         version: 5.101.0(@tanstack/react-query@5.101.0(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@axonivy/jsonrpc':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@axonivy/ui-components':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@axonivy/ui-icons':
-        specifier: ~12.0.16-next.762.6b30854
-        version: 12.0.16-next.762.6b30854
+        specifier: next-12.0.16
+        version: 12.0.16-next.772.7889a2d
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -149,20 +149,20 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@axonivy/eslint-config@12.0.16-next.762.6b30854':
-    resolution: {integrity: sha512-KiUDwGG6b1Sb3bJJ1AQ7c7VP6CQLeOgvrlNlAaD6ylslNy9r9eQSiI3Pt5TjFth5ZN2E11M4lSjfND1PO+VWOA==}
+  '@axonivy/eslint-config@12.0.16-next.772.7889a2d':
+    resolution: {integrity: sha512-LsT+DVsFh6nVq+TYQj/n6jiYmmyxexorGzGIrTX5Ei1HhRi+5PjP5X2mcXYh0WTxh37WRCgiT1rBZUjeuOBouw==}
 
-  '@axonivy/jsonrpc@12.0.16-next.762.6b30854':
-    resolution: {integrity: sha512-IN0XXN4237kZF6KJYx0BvINgjmjBFiOeBS3bUXgosQoUqdcJ+4HhZGJN51hrhHlghmGx/o9OUcQzYGcQEImCZA==}
+  '@axonivy/jsonrpc@12.0.16-next.772.7889a2d':
+    resolution: {integrity: sha512-BAb5mWs8uk0pfQ7a8dvbEMIpivf4Xt2n9nTkDHva8Oi7XBvgodo7xeihkcWydzyhootgxjUdwr6LCy5zm5evFg==}
 
-  '@axonivy/ui-components@12.0.16-next.762.6b30854':
-    resolution: {integrity: sha512-IspGyWPGpjNGMgpMWPyRU25thI8wt3gV7/7a5J2siRv5NCSC1DWxVGhmR79BUtNB7uFuDyMFHH4S8glZcwJPng==}
+  '@axonivy/ui-components@12.0.16-next.772.7889a2d':
+    resolution: {integrity: sha512-Q7eOumP74Tntrn+14+wTRWE70/BowLGA0/DfBsvZDzwAXUjLur039aOh8wihfhFx6YWEQb9rPv1ZFMk7NsXHrQ==}
     peerDependencies:
       '@axonivy/ui-icons': ~12.0.16-next
       react: ^18.2 || ^19.0
 
-  '@axonivy/ui-icons@12.0.16-next.762.6b30854':
-    resolution: {integrity: sha512-WQ1tIh/iYb87ZU1Ds13IOWpf1QRGZkQ2V57wg5ubVtxoml3u4q+ivzED7p2kLOFRKumtduwdxKTm4UgZ/jvFDQ==}
+  '@axonivy/ui-icons@12.0.16-next.772.7889a2d':
+    resolution: {integrity: sha512-/DcIbverUgoWKRFhTPIKqXA+z5zBH64bDV2vZwUaTRjGGsMnYgnOCUwQg5t7giv7F3aA2vwki8y8R9B/3NKSpQ==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1294,8 +1294,8 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@react-aria/dnd@3.12.0':
-    resolution: {integrity: sha512-FqAaxIMCgpq83UQhJRpSR+o3K4XQQYbJMKxhBWGL84Wn1p6m8QmWGvRKAiHeUoQXlY8R6KNxlMR/KjJvV8/lBA==}
+  '@react-aria/dnd@3.12.1':
+    resolution: {integrity: sha512-gAFsHChr2K9enfTOyY3h+7c+hb8fM7GGSWRlcE63If+jrdBRPicQ0wyiRr1ChFU3KVH3Nk2PZUUMET58QlUYVQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -1534,8 +1534,8 @@ packages:
   '@swc/helpers@0.5.19':
     resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
 
-  '@tanstack/eslint-plugin-query@5.100.11':
-    resolution: {integrity: sha512-4JfaSf6/ql9AFAsRWaWulz40gS86bDgSr15pWCI3o+oX3sdZ0ZR8AOeNrCEqyIrV6wFxnCfhFi1kWjOlZ+66Ew==}
+  '@tanstack/eslint-plugin-query@5.100.14':
+    resolution: {integrity: sha512-NbpiBCmeHTRuVHeV5+U+1bzmxyTW5Dzp2sCeE6Hx+ZJTJWFK9dsm8VZmRc7LQP9/ZORsF620PvgUk67AwiBo4A==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ^5.4.0 || ^6.0.0
@@ -1666,16 +1666,16 @@ packages:
   '@types/react@18.3.30':
     resolution: {integrity: sha512-3ek6mwJL5/VBewBcY4S66cqlCtK3qi4WIq37Z0m/NHw1hjhI7274Mx1qz/+ggSzyBCOEf7eHjBN6INjPAWYfYw==}
 
-  '@typescript-eslint/eslint-plugin@8.59.4':
-    resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
+  '@typescript-eslint/eslint-plugin@8.60.0':
+    resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.59.4
+      '@typescript-eslint/parser': ^8.60.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.59.4':
-    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+  '@typescript-eslint/parser@8.60.0':
+    resolution: {integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1687,8 +1687,18 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.60.0':
+    resolution: {integrity: sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.59.4':
     resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.60.0':
+    resolution: {integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.59.4':
@@ -1697,8 +1707,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/type-utils@8.59.4':
-    resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
+  '@typescript-eslint/tsconfig-utils@8.60.0':
+    resolution: {integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.60.0':
+    resolution: {integrity: sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1708,8 +1724,18 @@ packages:
     resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.60.0':
+    resolution: {integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.59.4':
     resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.60.0':
+    resolution: {integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1721,8 +1747,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.60.0':
+    resolution: {integrity: sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.59.4':
     resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vanilla-extract/css@1.17.4':
@@ -3413,8 +3450,8 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-hotkeys-hook@4.6.1:
-    resolution: {integrity: sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==}
+  react-hotkeys-hook@4.6.2:
+    resolution: {integrity: sha512-FmP+ZriY3EG59Ug/lxNfrObCnW9xQShgk7Nb83+CkpfkcCpfS95ydv+E9JuXA5cp8KtskU7LGlIARpkc92X22Q==}
     peerDependencies:
       react: '>=16.8.1'
       react-dom: '>=16.8.1'
@@ -3828,8 +3865,8 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.59.4:
-    resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
+  typescript-eslint@8.60.0:
+    resolution: {integrity: sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -4194,12 +4231,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@axonivy/eslint-config@12.0.16-next.762.6b30854(typescript@5.9.3)':
+  '@axonivy/eslint-config@12.0.16-next.772.7889a2d(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 9.39.4
-      '@tanstack/eslint-plugin-query': 5.100.11(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      '@tanstack/eslint-plugin-query': 5.100.14(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       eslint-formatter-checkstyle: 8.40.0
       eslint-plugin-playwright: 2.10.4(eslint@9.39.4)
@@ -4207,19 +4244,20 @@ snapshots:
       eslint-plugin-react-compiler: 19.1.0-rc.2(eslint@9.39.4)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
       eslint-plugin-testing-library: 7.16.2(eslint@9.39.4)(typescript@5.9.3)
-      typescript-eslint: 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      globals: 17.6.0
+      typescript-eslint: 8.60.0(eslint@9.39.4)(typescript@5.9.3)
     transitivePeerDependencies:
       - jiti
       - supports-color
       - typescript
 
-  '@axonivy/jsonrpc@12.0.16-next.762.6b30854':
+  '@axonivy/jsonrpc@12.0.16-next.772.7889a2d':
     dependencies:
       vscode-jsonrpc: 8.2.1
 
-  '@axonivy/ui-components@12.0.16-next.762.6b30854(@axonivy/ui-icons@12.0.16-next.762.6b30854)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@axonivy/ui-components@12.0.16-next.772.7889a2d(@axonivy/ui-icons@12.0.16-next.772.7889a2d)(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@axonivy/ui-icons': 12.0.16-next.762.6b30854
+      '@axonivy/ui-icons': 12.0.16-next.772.7889a2d
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4234,12 +4272,12 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/dnd': 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/dnd': 3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table': 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       downshift: 9.0.13(react@18.3.1)
       react: 18.3.1
-      react-hotkeys-hook: 4.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-hotkeys-hook: 4.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-resizable-panels: 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner: 1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
@@ -4247,7 +4285,7 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@axonivy/ui-icons@12.0.16-next.762.6b30854': {}
+  '@axonivy/ui-icons@12.0.16-next.772.7889a2d': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -5545,7 +5583,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-aria/dnd@3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-aria/dnd@3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.19
@@ -5732,7 +5770,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/eslint-plugin-query@5.100.11(eslint@9.39.4)(typescript@5.9.3)':
+  '@tanstack/eslint-plugin-query@5.100.14(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
@@ -5866,14 +5904,14 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.59.4
-      '@typescript-eslint/type-utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.4
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/type-utils': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
       eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -5882,12 +5920,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.4
-      '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.4
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       eslint: 9.39.4
       typescript: 5.9.3
@@ -5903,20 +5941,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.60.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.59.4':
     dependencies:
       '@typescript-eslint/types': 8.59.4
       '@typescript-eslint/visitor-keys': 8.59.4
 
+  '@typescript-eslint/scope-manager@8.60.0':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
+
   '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.4(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.60.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.59.4
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.60.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -5926,12 +5982,29 @@ snapshots:
 
   '@typescript-eslint/types@8.59.4': {}
 
+  '@typescript-eslint/types@8.60.0': {}
+
   '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.59.4(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
       '@typescript-eslint/types': 8.59.4
       '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.60.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -5952,9 +6025,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.60.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.59.4':
     dependencies:
       '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
   '@vanilla-extract/css@1.17.4':
@@ -7904,7 +7993,7 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-hotkeys-hook@4.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-hotkeys-hook@4.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8400,12 +8489,12 @@ snapshots:
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.59.4(eslint@9.39.4)(typescript@5.9.3):
+  typescript-eslint@8.60.0(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,3 +14,5 @@ publicHoistPattern:
 trustPolicy: no-downgrade
 trustPolicyIgnoreAfter: 43200 # minutes (30 days)
 verifyDepsBeforeRun: warn
+registries:
+  '@axonivy': 'https://npmjs-registry.ivyteam.ch/'


### PR DESCRIPTION
## Summary
- replace fixed Axon Ivy canary dependency specs with next-12.0.16 dist-tags
- move the Axon Ivy registry config from .npmrc to pnpm-workspace.yaml
- update Ivy helper scripts and Jenkins install/update ordering to avoid npm-check-updates and --no-frozen-lockfile